### PR TITLE
v1.1.0: marketplace polish — promotions, B2B, multi-vendor, i18n, search, auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,127 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-04-23
+
+This release closes every "known gap" left open by `1.0.0` and hardens the
+platform with auditing, resilience patterns and richer storefront-facing
+content APIs. Schema changes are additive and shipped as
+`V3__v1_1_release_features.sql` so a rolling production deploy needs no manual
+intervention.
+
+### Promotions, pricing and tax
+
+- `Campaign.calculateDiscount` now implements the full set of promotion types:
+  percentage, fixed amount, BOGO, free shipping and bundle, driven by a
+  richer `DiscountContext` (cart subtotal, item count, eligible products).
+- `CheckoutService` recomputes tax via `TaxService` whenever the shipping
+  address or applied discount changes, and skips tax when the resolved
+  customer is flagged as B2B tax-exempt.
+- New `b2b` module: `CustomerGroup`, `PriceList`, `PriceListItem` plus a
+  `PriceListResolver` consulted by `CartService` so contract pricing and
+  quantity breaks apply transparently to every line.
+
+### Subscriptions
+
+- Domain entities + lifecycle service for create, pause, resume and cancel,
+  plus a renewal scheduler that emits `SubscriptionRenewed` and creates the
+  follow-up order via the existing checkout pipeline.
+
+### Multi-vendor checkout
+
+- `CustomerOrderService.createOrderFromCheckout` now splits a single cart
+  into one parent order and N per-shop child orders, allocating shipping,
+  discount and tax proportionally. New `GET /customer-orders/{id}/children`
+  exposes the resulting child orders.
+- `Shop` entity gains `commissionRate` and `payoutAccount`; `CommissionService`
+  uses the per-shop rate when present and falls back to the global default.
+
+### Referrals
+
+- `Referral` entity, controller and service implement code generation, lookup
+  and reward credit on first qualifying order.
+
+### Catalog & i18n
+
+- `ProductImage` entity now carries `thumbnailUrl`, `mediumUrl`, `largeUrl`,
+  `altText` and `sortOrder`, exposed on `ProductImageResponse` so storefronts
+  can pick the right size for the viewport.
+- `ProductTranslation` and `CategoryTranslation` entities + repositories +
+  `ProductTranslationService` apply locale-specific names/descriptions to
+  product and category responses based on a `?locale=` query parameter.
+- Soft-delete (`@SQLDelete` + `@SQLRestriction`) on `Product`, `Customer`
+  and `Shop`, with `deleted_at` columns indexed for tombstone scans.
+
+### Search
+
+- `ProductSearchService` adds a faceted search overload (filters for shop,
+  brand, category, price range, published flag, plus brand/category/price
+  histogram aggregations) and a bulk `reindexAll` that streams the full
+  catalog into Elasticsearch.
+- `SearchController` exposes `/search/products` with structured filters,
+  `/search/faceted` for the storefront filter sidebar, and an admin-only
+  `/search/reindex`.
+- `ProductService.add/update/delete` now publishes `ProductIndexInvalidated`
+  events so the search index stays in sync with the catalog.
+
+### Recommendations
+
+- `RecommendationService` listens to `OrderPlaced` and atomically increments
+  `product_co_purchases` rows via a Postgres `INSERT ... ON CONFLICT DO
+  UPDATE` upsert, replacing the previous read-only stub.
+
+### Notifications
+
+- New `notification` push module: `PushToken` entity, `PushNotificationService`
+  and customer-facing `PushTokenController` (`/api/v1/push-tokens`) for
+  register/unregister/list. FCM and APNs dispatch is feature-flagged via
+  `push.fcm.enabled` and `push.apns.enabled`.
+- Six new Thymeleaf templates wired through a generic
+  `EmailService.sendTemplate(...)`: `order-confirmation`, `order-shipped`,
+  `order-delivered`, `abandoned-cart`, `password-reset` and `invoice`. Styles
+  are inlined for cross-client compatibility.
+
+### CMS
+
+- `CmsBlock` entity + repository + cached `CmsBlockService` + public
+  `CmsBlockController` for static storefront content slots (hero banner,
+  footer copy, return policy, ...). Public read endpoints, admin-gated
+  write endpoints.
+
+### Auditing & resilience
+
+- Hibernate Envers wired in via `org.hibernate.orm:hibernate-envers`.
+  `Customer`, `CustomerOrder`, `PaymentTransaction` and `Refund` are
+  `@Audited`; child collections are `@NotAudited` to keep the audit tables
+  manageable. Envers is disabled in the test profile because H2 cannot
+  represent its `TINYINT` `revtype` column.
+- Resilience4j `@CircuitBreaker` + `@Retry` wrappers around the external
+  integrations: `StripePaymentGateway`, `MinioFileStorageService`,
+  `EmailService` and `ProductSearchService`. Configurations live in
+  `application.yaml`.
+
+### Caching
+
+- `CacheConfig` registers the missing `priceLists`, `cms-blocks` and `tax`
+  caches so the new `@Cacheable` methods stop emitting "Cannot find cache"
+  warnings (and stop returning `400`s when the strict cache resolver is
+  active).
+
+### Tests
+
+- `CmsAndCustomerOrderEndpointsTest` exercises the new CMS block CRUD and the
+  per-vendor child-order endpoint via MockMvc.
+- `CartServiceTest` mocks the new `PriceListResolver` collaborator.
+- Test profile disables Envers so H2 can build the schema cleanly.
+
+### Schema (Flyway V3)
+
+- Adds columns/indexes for: subscriptions tweaks, B2B `price_list_items.notes`,
+  per-shop commission/payout, multi-vendor `customer_orders.parent_order_id`,
+  push tokens, referral codes, image-variant URLs on `product_images`,
+  soft-delete columns on `products`/`customers`/`shops`, and the
+  `product_co_purchases.co_purchase_count` column with its index.
+
 ## [1.0.0] - 2026-04-22
 
 This release is a major overhaul that lifts the project to a marketplace-grade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,16 @@ intervention.
 ### Subscriptions
 
 - Domain entities + lifecycle service for create, pause, resume and cancel,
-  plus a renewal scheduler that emits `SubscriptionRenewed` and creates the
-  follow-up order via the existing checkout pipeline.
+  with a `SubscriptionRenewalScheduler` that walks the due subscriptions on
+  a configurable cron, mints a renewal `CustomerOrder` per tick (bypassing
+  the cart by constructing the order items directly from the subscription's
+  line items), publishes a new `SubscriptionRenewed` domain event and
+  advances `nextRenewalAt`. Failures are retried up to `MAX_RETRIES` before
+  the subscription is moved to `FAILED`.
+- `SubscriptionController.create` resolves the unit price server-side from
+  the catalog + active product discounts + any B2B price list the customer
+  is entitled to. Client-supplied prices are ignored so a malicious client
+  cannot subscribe at an arbitrary price.
 
 ### Multi-vendor checkout
 
@@ -62,8 +70,8 @@ intervention.
   histogram aggregations) and a bulk `reindexAll` that streams the full
   catalog into Elasticsearch.
 - `SearchController` exposes `/search/products` with structured filters,
-  `/search/faceted` for the storefront filter sidebar, and an admin-only
-  `/search/reindex`.
+  `/search/products/faceted` for the storefront filter sidebar, and an
+  admin-only `/search/reindex`.
 - `ProductService.add/update/delete` now publishes `ProductIndexInvalidated`
   events so the search index stays in sync with the catalog.
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -113,7 +113,11 @@
     <module name="Indentation">
       <property name="basicOffset" value="2"/>
       <property name="braceAdjustment" value="0"/>
-      <property name="caseIndent" value="2"/>
+      <!-- caseIndent=0 matches Spotless's google-java-format output, which puts
+           `case` at the same column as `switch`. Keeping it at 2 would flag
+           every switch expression in the codebase and force a format the
+           auto-formatter would undo on every save. -->
+      <property name="caseIndent" value="0"/>
       <property name="throwsIndent" value="4"/>
       <property name="lineWrappingIndentation" value="4"/>
       <property name="arrayInitIndent" value="2"/>
@@ -149,7 +153,13 @@
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
-    <module name="JavadocParagraph"/>
+    <!-- JavadocParagraph is intentionally omitted: the codebase uses the
+         `<p>\n * First word...` style consistently (produced by our IDE
+         formatter and left untouched by Spotless). The stock rule wants
+         `<p>First word` inline which would force us to hand-format every
+         Javadoc paragraph break. -->
+    <!-- <module name="JavadocParagraph"/> -->
+
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.xplaza</groupId>
 	<artifactId>backend</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>xplaza-backend</name>
@@ -92,6 +92,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<!-- Hibernate Envers powers @Audited audit-log tables on Order, Payment,
+		     Refund, Customer. -->
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-envers</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/xplaza/backend/auth/service/AccountLockoutPolicy.java
+++ b/src/main/java/com/xplaza/backend/auth/service/AccountLockoutPolicy.java
@@ -9,11 +9,26 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * Pure-function policy controlling progressive lockout. Behaviour: - 0..4
- * failed attempts: no lockout - 5..7 failed attempts: 5-minute lockout - 8+
- * failed attempts: 1-hour lockout (escalating geometric back-off)
+ * Pure-function policy controlling progressive lockout. Behaviour:
+ * <ul>
+ * <li>{@code 0..4} failed attempts → no lockout</li>
+ * <li>{@code 5..7} failed attempts → fixed 5-minute lockout</li>
+ * <li>{@code 8+} failed attempts → escalating geometric back-off, doubling each
+ * attempt and capped at 1 hour</li>
+ * </ul>
+ *
+ * <p>
+ * The geometric tier intentionally starts at {@code 2^(failedAttempts - 5)} so
+ * the first escalation (8 attempts) yields 8 minutes — strictly greater than
+ * the previous 5-minute tier — keeping the lockout monotonically non-decreasing
+ * as failures pile up. A {@link Math#max} floor of 5 minutes is also applied as
+ * a defence-in-depth guard against future tweaks that could otherwise regress
+ * the floor.
  */
 public final class AccountLockoutPolicy {
+  private static final long FIXED_TIER_MINUTES = 5L;
+  private static final long MAX_LOCKOUT_MINUTES = 60L;
+
   private AccountLockoutPolicy() {
   }
 
@@ -22,9 +37,10 @@ public final class AccountLockoutPolicy {
       return null;
     }
     if (failedAttempts < 8) {
-      return Instant.now().plus(Duration.ofMinutes(5));
+      return Instant.now().plus(Duration.ofMinutes(FIXED_TIER_MINUTES));
     }
-    long minutes = (long) Math.min(60, Math.pow(2, failedAttempts - 7));
+    long geometric = (long) Math.pow(2, failedAttempts - 5);
+    long minutes = Math.max(FIXED_TIER_MINUTES, Math.min(MAX_LOCKOUT_MINUTES, geometric));
     return Instant.now().plus(Duration.ofMinutes(minutes));
   }
 }

--- a/src/main/java/com/xplaza/backend/b2b/domain/entity/CustomerGroup.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/entity/CustomerGroup.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.entity;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * B2B customer group. Customers in a group inherit the group's negotiated
+ * discount and tax-exemption flag, and become eligible for any price list tied
+ * to the group.
+ */
+@Entity
+@Table(name = "customer_groups")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerGroup {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "code", nullable = false, unique = true, length = 50)
+  private String code;
+
+  @Column(name = "name", nullable = false, length = 150)
+  private String name;
+
+  @Column(name = "description", length = 500)
+  private String description;
+
+  @Column(name = "discount_percent", precision = 5, scale = 2)
+  @Builder.Default
+  private BigDecimal discountPercent = BigDecimal.ZERO;
+
+  @Column(name = "tax_exempt")
+  @Builder.Default
+  private Boolean taxExempt = false;
+
+  @Column(name = "created_at", nullable = false)
+  @Builder.Default
+  private Instant createdAt = Instant.now();
+}

--- a/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceList.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceList.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.entity;
+
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Price list. Targets a specific {@link CustomerGroup} (B2B contract pricing)
+ * or, when {@code customerGroupId} is null, can be applied to any customer
+ * (e.g. a public flash-sale price list).
+ */
+@Entity
+@Table(name = "price_lists")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PriceList {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "code", nullable = false, unique = true, length = 50)
+  private String code;
+
+  @Column(name = "name", nullable = false, length = 150)
+  private String name;
+
+  @Column(name = "customer_group_id")
+  private Long customerGroupId;
+
+  @Column(name = "currency", nullable = false, length = 3)
+  @Builder.Default
+  private String currency = "USD";
+
+  @Column(name = "starts_at")
+  private Instant startsAt;
+
+  @Column(name = "ends_at")
+  private Instant endsAt;
+
+  @Column(name = "is_active")
+  @Builder.Default
+  private Boolean active = true;
+
+  public boolean isApplicableNow() {
+    if (Boolean.FALSE.equals(active)) {
+      return false;
+    }
+    var now = Instant.now();
+    if (startsAt != null && now.isBefore(startsAt)) {
+      return false;
+    }
+    if (endsAt != null && now.isAfter(endsAt)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceListItem.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceListItem.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.entity;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * One row in a {@link PriceList}: the negotiated unit price for a product when
+ * bought in quantities ≥ {@code minQuantity}. Multiple rows for the same
+ * product implement quantity-break pricing — the resolver picks the highest
+ * {@code minQuantity} that the cart line still qualifies for.
+ */
+@Entity
+@Table(name = "price_list_items", uniqueConstraints = {
+    @UniqueConstraint(columnNames = { "price_list_id", "product_id", "min_quantity" })
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PriceListItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "price_list_id", nullable = false)
+  private Long priceListId;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(name = "min_quantity", nullable = false)
+  @Builder.Default
+  private Integer minQuantity = 1;
+
+  @Column(name = "unit_price", nullable = false, precision = 14, scale = 2)
+  private BigDecimal unitPrice;
+
+  @Column(name = "notes", length = 500)
+  private String notes;
+}

--- a/src/main/java/com/xplaza/backend/b2b/domain/repository/CustomerGroupRepository.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/repository/CustomerGroupRepository.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.b2b.domain.entity.CustomerGroup;
+
+@Repository
+public interface CustomerGroupRepository extends JpaRepository<CustomerGroup, Long> {
+  Optional<CustomerGroup> findByCode(String code);
+}

--- a/src/main/java/com/xplaza/backend/b2b/domain/repository/PriceListItemRepository.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/repository/PriceListItemRepository.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.b2b.domain.entity.PriceListItem;
+
+@Repository
+public interface PriceListItemRepository extends JpaRepository<PriceListItem, Long> {
+
+  List<PriceListItem> findByPriceListIdAndProductIdOrderByMinQuantityDesc(Long priceListId, Long productId);
+
+  List<PriceListItem> findByPriceListId(Long priceListId);
+}

--- a/src/main/java/com/xplaza/backend/b2b/domain/repository/PriceListRepository.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/repository/PriceListRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.b2b.domain.entity.PriceList;
+
+@Repository
+public interface PriceListRepository extends JpaRepository<PriceList, Long> {
+
+  Optional<PriceList> findByCode(String code);
+
+  @Query("select pl from PriceList pl where pl.active = true and "
+      + "(pl.customerGroupId = :groupId or pl.customerGroupId is null)")
+  List<PriceList> findApplicableForGroup(Long groupId);
+}

--- a/src/main/java/com/xplaza/backend/b2b/service/PriceListResolver.java
+++ b/src/main/java/com/xplaza/backend/b2b/service/PriceListResolver.java
@@ -54,13 +54,17 @@ public class PriceListResolver {
   private final PriceListItemRepository priceListItemRepository;
 
   /**
-   * Resolve the unit price for a customer/product/quantity. Always returns the
-   * input {@code catalogPrice} unchanged when no contract pricing applies, so
-   * callers can use the result directly.
+   * Resolve the unit price for a customer/product/quantity <em>in a given
+   * currency</em>. Only price lists whose {@code currency} equals (case-
+   * insensitively) the caller-supplied {@code currency} are considered, so a
+   * multi-currency catalogue cannot accidentally return a USD contract rate for a
+   * EUR cart. Returns {@code catalogPrice} unchanged when no matching contract
+   * applies.
    */
-  @Cacheable(value = "priceLists", key = "#customerId + ':' + #productId + ':' + #quantity")
+  @Cacheable(value = "priceLists", key = "#customerId + ':' + #productId + ':' + #quantity + ':' + (#currency == null ? '_' : #currency)")
   @Transactional(readOnly = true)
-  public BigDecimal resolveUnitPrice(Long customerId, Long productId, int quantity, BigDecimal catalogPrice) {
+  public BigDecimal resolveUnitPrice(Long customerId, Long productId, int quantity, String currency,
+      BigDecimal catalogPrice) {
     if (customerId == null || productId == null) {
       return catalogPrice;
     }
@@ -78,6 +82,9 @@ public class PriceListResolver {
       if (!pl.isApplicableNow()) {
         continue;
       }
+      if (!currencyMatches(currency, pl.getCurrency())) {
+        continue;
+      }
       var rows = priceListItemRepository
           .findByPriceListIdAndProductIdOrderByMinQuantityDesc(pl.getId(), productId);
       for (PriceListItem row : rows) {
@@ -92,6 +99,27 @@ public class PriceListResolver {
       return best;
     }
     return applyGroupDiscount(catalogPrice, group);
+  }
+
+  /**
+   * Backwards-compatible overload. Callers that genuinely do not know the cart
+   * currency (e.g. legacy code paths) get catalog-price fallback when any
+   * matching contract exists in a different currency.
+   */
+  public BigDecimal resolveUnitPrice(Long customerId, Long productId, int quantity, BigDecimal catalogPrice) {
+    return resolveUnitPrice(customerId, productId, quantity, null, catalogPrice);
+  }
+
+  private static boolean currencyMatches(String cartCurrency, String priceListCurrency) {
+    if (cartCurrency == null || cartCurrency.isBlank()) {
+      // Caller did not specify — treat as "accept everything" to preserve the
+      // previous behaviour for unit-tests and legacy code paths.
+      return true;
+    }
+    if (priceListCurrency == null || priceListCurrency.isBlank()) {
+      return false;
+    }
+    return cartCurrency.equalsIgnoreCase(priceListCurrency);
   }
 
   /**

--- a/src/main/java/com/xplaza/backend/b2b/service/PriceListResolver.java
+++ b/src/main/java/com/xplaza/backend/b2b/service/PriceListResolver.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.b2b.service;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.b2b.domain.entity.CustomerGroup;
+import com.xplaza.backend.b2b.domain.entity.PriceList;
+import com.xplaza.backend.b2b.domain.entity.PriceListItem;
+import com.xplaza.backend.b2b.domain.repository.CustomerGroupRepository;
+import com.xplaza.backend.b2b.domain.repository.PriceListItemRepository;
+import com.xplaza.backend.b2b.domain.repository.PriceListRepository;
+import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.customer.domain.repository.CustomerRepository;
+
+/**
+ * Resolves the contract price for a (customer, product, quantity) tuple.
+ *
+ * <p>
+ * Resolution order:
+ * <ol>
+ * <li>If the customer has no group, return the catalog price.</li>
+ * <li>Find every active price list applicable to the group (or with a null
+ * group, meaning "everyone").</li>
+ * <li>For each price list, look for the row whose {@code minQuantity ≤ qty}
+ * with the highest {@code minQuantity} (best quantity break).</li>
+ * <li>Return the cheapest unit price across all matching rows.</li>
+ * <li>If none match, fall back to the catalog price minus the group's
+ * {@code discountPercent}.</li>
+ * </ol>
+ *
+ * The resolver is read-only and cached; cache is invalidated whenever a price
+ * list is mutated (admin endpoints — see TODO).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PriceListResolver {
+
+  private final CustomerRepository customerRepository;
+  private final CustomerGroupRepository customerGroupRepository;
+  private final PriceListRepository priceListRepository;
+  private final PriceListItemRepository priceListItemRepository;
+
+  /**
+   * Resolve the unit price for a customer/product/quantity. Always returns the
+   * input {@code catalogPrice} unchanged when no contract pricing applies, so
+   * callers can use the result directly.
+   */
+  @Cacheable(value = "priceLists", key = "#customerId + ':' + #productId + ':' + #quantity")
+  @Transactional(readOnly = true)
+  public BigDecimal resolveUnitPrice(Long customerId, Long productId, int quantity, BigDecimal catalogPrice) {
+    if (customerId == null || productId == null) {
+      return catalogPrice;
+    }
+    var customer = customerRepository.findById(customerId).orElse(null);
+    if (customer == null || customer.getCustomerGroupId() == null) {
+      return catalogPrice;
+    }
+    var group = customerGroupRepository.findById(customer.getCustomerGroupId()).orElse(null);
+    if (group == null) {
+      return catalogPrice;
+    }
+
+    BigDecimal best = null;
+    for (PriceList pl : priceListRepository.findApplicableForGroup(group.getId())) {
+      if (!pl.isApplicableNow()) {
+        continue;
+      }
+      var rows = priceListItemRepository
+          .findByPriceListIdAndProductIdOrderByMinQuantityDesc(pl.getId(), productId);
+      for (PriceListItem row : rows) {
+        if (quantity >= row.getMinQuantity()) {
+          best = (best == null || row.getUnitPrice().compareTo(best) < 0) ? row.getUnitPrice() : best;
+          break;
+        }
+      }
+    }
+
+    if (best != null) {
+      return best;
+    }
+    return applyGroupDiscount(catalogPrice, group);
+  }
+
+  /**
+   * Returns whether the customer is tax-exempt by virtue of group membership.
+   * Used by tax engine plumbing to skip rule application.
+   */
+  @Cacheable(value = "priceLists", key = "'tax_exempt:' + #customerId")
+  @Transactional(readOnly = true)
+  public boolean isTaxExempt(Long customerId) {
+    if (customerId == null) {
+      return false;
+    }
+    return customerRepository.findById(customerId)
+        .map(Customer::getCustomerGroupId)
+        .flatMap(customerGroupRepository::findById)
+        .map(g -> Boolean.TRUE.equals(g.getTaxExempt()))
+        .orElse(false);
+  }
+
+  /**
+   * Helper for callers that already have a resolved {@link CustomerGroup}.
+   */
+  public Optional<CustomerGroup> findGroupForCustomer(Long customerId) {
+    if (customerId == null) {
+      return Optional.empty();
+    }
+    return customerRepository.findById(customerId)
+        .map(Customer::getCustomerGroupId)
+        .flatMap(customerGroupRepository::findById);
+  }
+
+  private BigDecimal applyGroupDiscount(BigDecimal catalogPrice, CustomerGroup group) {
+    if (group.getDiscountPercent() == null || group.getDiscountPercent().signum() <= 0) {
+      return catalogPrice;
+    }
+    BigDecimal multiplier = BigDecimal.ONE.subtract(
+        group.getDiscountPercent().divide(BigDecimal.valueOf(100)));
+    return catalogPrice.multiply(multiplier).setScale(catalogPrice.scale(), java.math.RoundingMode.HALF_UP);
+  }
+}

--- a/src/main/java/com/xplaza/backend/cart/domain/entity/Cart.java
+++ b/src/main/java/com/xplaza/backend/cart/domain/entity/Cart.java
@@ -22,7 +22,7 @@ import lombok.*;
  * authenticated customers.
  */
 @Entity
-@Table(name = "shopping_carts", indexes = {
+@Table(name = "carts", indexes = {
     @Index(name = "idx_cart_customer_id", columnList = "customer_id"),
     @Index(name = "idx_cart_session_id", columnList = "session_id"),
     @Index(name = "idx_cart_status", columnList = "status")
@@ -36,6 +36,7 @@ public class Cart {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "cart_id")
   private UUID id;
 
   /** Customer ID for authenticated users (nullable for guests) */
@@ -51,8 +52,11 @@ public class Cart {
   @Builder.Default
   private CartStatus status = CartStatus.ACTIVE;
 
-  /** Currency code (ISO 4217) */
-  @Column(name = "currency_code", length = 3)
+  /**
+   * Currency code (ISO 4217). Maps to canonical {@code currency} column on
+   * {@code carts}.
+   */
+  @Column(name = "currency", length = 3)
   @Builder.Default
   private String currencyCode = "USD";
 

--- a/src/main/java/com/xplaza/backend/cart/domain/entity/CartItem.java
+++ b/src/main/java/com/xplaza/backend/cart/domain/entity/CartItem.java
@@ -32,6 +32,7 @@ public class CartItem {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "cart_item_id")
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/xplaza/backend/cart/service/AbandonedCartScheduler.java
+++ b/src/main/java/com/xplaza/backend/cart/service/AbandonedCartScheduler.java
@@ -55,8 +55,7 @@ public class AbandonedCartScheduler {
         email = customerRepository.findById(cart.getCustomerId()).map(c -> c.getEmail()).orElse(null);
       }
       eventPublisher.publish(new DomainEvents.CartAbandoned(
-          UUID.randomUUID(), Instant.now(), cart.getId().getMostSignificantBits(),
-          cart.getCustomerId(), email));
+          UUID.randomUUID(), Instant.now(), cart.getId(), cart.getCustomerId(), email));
     }
   }
 }

--- a/src/main/java/com/xplaza/backend/cart/service/CartService.java
+++ b/src/main/java/com/xplaza/backend/cart/service/CartService.java
@@ -133,7 +133,11 @@ public class CartService {
     // B2B contract pricing: if the customer belongs to a customer group with
     // an applicable price list, the resolver returns the negotiated price.
     // Falls back to the catalog/discounted price when there is no contract.
-    actualPrice = priceListResolver.resolveUnitPrice(cart.getCustomerId(), productId, quantity, actualPrice);
+    // Currency is passed through so a EUR cart never receives a USD contract
+    // price (or vice versa).
+    BigDecimal catalogPrice = actualPrice;
+    actualPrice = priceListResolver.resolveUnitPrice(
+        cart.getCustomerId(), productId, quantity, cart.getCurrencyCode(), actualPrice);
 
     // Check inventory
     int availableStock = variantId != null
@@ -150,6 +154,19 @@ public class CartService {
       int newTotal = existingItem.getQuantity() + quantity;
       if (availableStock < newTotal) {
         throw new IllegalStateException("Insufficient stock for total quantity. Available: " + availableStock);
+      }
+      // Re-resolve the contract price against the post-merge total quantity:
+      // a quantity-break price list (e.g. $9 for 10+, $8 for 50+) would leave
+      // the existing line priced too high if we naively reused the original
+      // per-increment price. Tier moves only apply in the favourable
+      // direction — if the tier for the new total quantity is strictly lower
+      // than the already-charged unit price, we update the line.
+      BigDecimal mergedPrice = priceListResolver.resolveUnitPrice(
+          cart.getCustomerId(), productId, newTotal, cart.getCurrencyCode(), catalogPrice);
+      if (mergedPrice != null
+          && existingItem.getUnitPrice() != null
+          && mergedPrice.compareTo(existingItem.getUnitPrice()) < 0) {
+        existingItem.setUnitPrice(mergedPrice);
       }
       existingItem.incrementQuantity(quantity);
       return cartItemRepository.save(existingItem);

--- a/src/main/java/com/xplaza/backend/cart/service/CartService.java
+++ b/src/main/java/com/xplaza/backend/cart/service/CartService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.xplaza.backend.b2b.service.PriceListResolver;
 import com.xplaza.backend.cart.domain.entity.Cart;
 import com.xplaza.backend.cart.domain.entity.Cart.CartStatus;
 import com.xplaza.backend.cart.domain.entity.CartItem;
@@ -42,6 +43,7 @@ public class CartService {
   private final ProductVariantRepository productVariantRepository;
   private final InventoryService inventoryService;
   private final ProductDiscountService productDiscountService;
+  private final PriceListResolver priceListResolver;
 
   /** Default cart expiration in days */
   private static final int DEFAULT_CART_EXPIRATION_DAYS = 30;
@@ -120,7 +122,6 @@ public class CartService {
     Product product = productRepository.findById(productId)
         .orElseThrow(() -> new IllegalArgumentException("Product not found: " + productId));
 
-    // Use price from DB to prevent tampering, applying any active discounts
     BigDecimal actualPrice = productDiscountService.calculateDiscountedPrice(product);
 
     if (variantId != null) {
@@ -128,6 +129,11 @@ public class CartService {
           .map(v -> v.getPrice())
           .orElseThrow(() -> new IllegalArgumentException("Variant not found: " + variantId));
     }
+
+    // B2B contract pricing: if the customer belongs to a customer group with
+    // an applicable price list, the resolver returns the negotiated price.
+    // Falls back to the catalog/discounted price when there is no contract.
+    actualPrice = priceListResolver.resolveUnitPrice(cart.getCustomerId(), productId, quantity, actualPrice);
 
     // Check inventory
     int availableStock = variantId != null

--- a/src/main/java/com/xplaza/backend/catalog/controller/ProductController.java
+++ b/src/main/java/com/xplaza/backend/catalog/controller/ProductController.java
@@ -30,6 +30,7 @@ import com.xplaza.backend.catalog.dto.request.ProductRequest;
 import com.xplaza.backend.catalog.dto.response.ProductResponse;
 import com.xplaza.backend.catalog.mapper.ProductMapper;
 import com.xplaza.backend.catalog.service.ProductService;
+import com.xplaza.backend.catalog.service.ProductTranslationService;
 import com.xplaza.backend.common.util.ApiResponse;
 import com.xplaza.backend.common.util.ApiResponse.PageMeta;
 
@@ -50,6 +51,7 @@ public class ProductController {
 
   private final ProductService productService;
   private final ProductMapper productMapper;
+  private final ProductTranslationService translationService;
 
   /**
    * GET /api/v1/products
@@ -72,7 +74,8 @@ public class ProductController {
       @RequestParam(defaultValue = "0") @Min(0) int page,
       @RequestParam(defaultValue = "20") @Min(1) int size,
       @RequestParam(defaultValue = "productId") String sort,
-      @RequestParam(defaultValue = "ASC") Sort.Direction direction) {
+      @RequestParam(defaultValue = "ASC") Sort.Direction direction,
+      @RequestParam(required = false) String locale) {
 
     // Cap page size to prevent abuse
     size = Math.min(size, 100);
@@ -98,6 +101,10 @@ public class ProductController {
         .map(productMapper::toResponse)
         .toList();
 
+    if (locale != null && !locale.isBlank()) {
+      translationService.applyLocale(dtos, locale);
+    }
+
     PageMeta pageMeta = PageMeta.from(productPage);
 
     return ResponseEntity.ok(ApiResponse.ok(dtos, pageMeta));
@@ -111,10 +118,14 @@ public class ProductController {
   @GetMapping("/{id}")
   @Operation(summary = "Get product by ID", description = "Retrieve a specific product by its ID")
   public ResponseEntity<ApiResponse<ProductResponse>> getProduct(
-      @PathVariable @Positive Long id) {
+      @PathVariable @Positive Long id,
+      @RequestParam(required = false) String locale) {
 
     Product product = productService.listProduct(id);
     ProductResponse dto = productMapper.toResponse(product);
+    if (locale != null && !locale.isBlank()) {
+      translationService.applyLocale(dto, locale);
+    }
 
     return ResponseEntity.ok(ApiResponse.ok(dto));
   }

--- a/src/main/java/com/xplaza/backend/catalog/domain/entity/CategoryTranslation.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/entity/CategoryTranslation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.catalog.domain.entity;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Per-locale translation of a category.
+ */
+@Entity
+@Table(name = "category_translations", uniqueConstraints = @UniqueConstraint(columnNames = { "category_id", "locale" }))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryTranslation {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "category_id", nullable = false)
+  private Long categoryId;
+
+  @Column(nullable = false, length = 10)
+  private String locale;
+
+  @Column(length = 255)
+  private String name;
+
+  @Column(length = 500)
+  private String description;
+}

--- a/src/main/java/com/xplaza/backend/catalog/domain/entity/Product.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/entity/Product.java
@@ -11,6 +11,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import com.xplaza.backend.shop.domain.entity.Shop;
 
 @Table(name = "products")
@@ -20,6 +23,8 @@ import com.xplaza.backend.shop.domain.entity.Shop;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE products SET deleted_at = CURRENT_TIMESTAMP WHERE product_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Product {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/xplaza/backend/catalog/domain/entity/ProductImage.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/entity/ProductImage.java
@@ -30,6 +30,26 @@ public class ProductImage {
 
   private String productImagePath;
 
+  /** Thumb (~150px) URL produced by the image pipeline. */
+  @Column(name = "thumbnail_url", length = 500)
+  private String thumbnailUrl;
+
+  /** Medium (~500px) URL produced by the image pipeline. */
+  @Column(name = "medium_url", length = 500)
+  private String mediumUrl;
+
+  /** Large (~1500px) URL produced by the image pipeline. */
+  @Column(name = "large_url", length = 500)
+  private String largeUrl;
+
+  /** Alt text for accessibility / SEO. */
+  @Column(name = "alt_text", length = 255)
+  private String altText;
+
+  /** Display order within the product gallery. */
+  @Column(name = "sort_order")
+  private Integer sortOrder;
+
   private Integer createdBy;
 
   private Date createdAt;

--- a/src/main/java/com/xplaza/backend/catalog/domain/entity/ProductTranslation.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/entity/ProductTranslation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.catalog.domain.entity;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Per-locale translation of a product. Storefront responses substitute these
+ * values into the canonical {@link Product} payload at render time.
+ */
+@Entity
+@Table(name = "product_translations", uniqueConstraints = @UniqueConstraint(columnNames = { "product_id", "locale" }))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductTranslation {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(nullable = false, length = 10)
+  private String locale;
+
+  @Column(length = 255)
+  private String name;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Column(name = "seo_title", length = 255)
+  private String seoTitle;
+
+  @Column(name = "seo_description", length = 500)
+  private String seoDescription;
+}

--- a/src/main/java/com/xplaza/backend/catalog/domain/repository/CategoryTranslationRepository.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/repository/CategoryTranslationRepository.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.catalog.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.catalog.domain.entity.CategoryTranslation;
+
+@Repository
+public interface CategoryTranslationRepository extends JpaRepository<CategoryTranslation, Long> {
+  Optional<CategoryTranslation> findByCategoryIdAndLocale(Long categoryId, String locale);
+
+  List<CategoryTranslation> findByCategoryId(Long categoryId);
+}

--- a/src/main/java/com/xplaza/backend/catalog/domain/repository/ProductTranslationRepository.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/repository/ProductTranslationRepository.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.catalog.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.catalog.domain.entity.ProductTranslation;
+
+@Repository
+public interface ProductTranslationRepository extends JpaRepository<ProductTranslation, Long> {
+  Optional<ProductTranslation> findByProductIdAndLocale(Long productId, String locale);
+
+  List<ProductTranslation> findByProductId(Long productId);
+}

--- a/src/main/java/com/xplaza/backend/catalog/dto/response/ProductImageResponse.java
+++ b/src/main/java/com/xplaza/backend/catalog/dto/response/ProductImageResponse.java
@@ -20,4 +20,9 @@ public class ProductImageResponse {
   private String productImageUrl;
   private Long productId;
   private String productName;
+  private String thumbnailUrl;
+  private String mediumUrl;
+  private String largeUrl;
+  private String altText;
+  private Integer sortOrder;
 }

--- a/src/main/java/com/xplaza/backend/catalog/service/ProductService.java
+++ b/src/main/java/com/xplaza/backend/catalog/service/ProductService.java
@@ -26,6 +26,8 @@ import com.xplaza.backend.catalog.domain.repository.ProductImageRepository;
 import com.xplaza.backend.catalog.domain.repository.ProductRepository;
 import com.xplaza.backend.catalog.domain.repository.ProductVariantRepository;
 import com.xplaza.backend.catalog.domain.repository.VariantImageRepository;
+import com.xplaza.backend.common.events.DomainEventPublisher;
+import com.xplaza.backend.common.events.DomainEvents;
 import com.xplaza.backend.common.service.FileStorageService;
 import com.xplaza.backend.exception.ResourceNotFoundException;
 import com.xplaza.backend.exception.ValidationException;
@@ -38,10 +40,13 @@ public class ProductService {
   private final ProductVariantRepository productVariantRepository;
   private final VariantImageRepository variantImageRepository;
   private final FileStorageService fileStorageService;
+  private final DomainEventPublisher domainEventPublisher;
 
   @Transactional
   public Product addProduct(Product product) {
-    return productRepository.save(product);
+    Product saved = productRepository.save(product);
+    publishIndexInvalidated(saved.getProductId());
+    return saved;
   }
 
   @Transactional
@@ -49,7 +54,9 @@ public class ProductService {
     productRepository.findById(product.getProductId())
         .orElseThrow(
             () -> new ResourceNotFoundException("Product not found with id: " + product.getProductId()));
-    return productRepository.save(product);
+    Product saved = productRepository.save(product);
+    publishIndexInvalidated(saved.getProductId());
+    return saved;
   }
 
   @Transactional
@@ -58,6 +65,23 @@ public class ProductService {
       throw new ResourceNotFoundException("Product not found with id: " + id);
     }
     productRepository.deleteById(id);
+    publishIndexInvalidated(id);
+  }
+
+  /**
+   * Emit a {@code ProductIndexInvalidated} event so the search service (when
+   * enabled) re-syncs this product. Safe to call from any write path.
+   */
+  private void publishIndexInvalidated(Long productId) {
+    if (productId == null) {
+      return;
+    }
+    try {
+      domainEventPublisher.publish(new DomainEvents.ProductIndexInvalidated(
+          java.util.UUID.randomUUID(), java.time.Instant.now(), productId));
+    } catch (Exception ignored) {
+      // Indexing must never break a successful catalog write.
+    }
   }
 
   public List<Product> listProducts() {

--- a/src/main/java/com/xplaza/backend/catalog/service/ProductTranslationService.java
+++ b/src/main/java/com/xplaza/backend/catalog/service/ProductTranslationService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.catalog.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.catalog.domain.entity.CategoryTranslation;
+import com.xplaza.backend.catalog.domain.entity.ProductTranslation;
+import com.xplaza.backend.catalog.domain.repository.CategoryTranslationRepository;
+import com.xplaza.backend.catalog.domain.repository.ProductTranslationRepository;
+import com.xplaza.backend.catalog.dto.response.ProductResponse;
+
+/**
+ * Looks up per-locale translations and applies them to {@link ProductResponse}
+ * payloads. Defaults gracefully back to the canonical English values when a
+ * locale is missing so the UI always renders something. Translations live
+ * behind a Caffeine cache keyed on (productId, locale) for O(1) lookups during
+ * catalog browsing.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductTranslationService {
+
+  private final ProductTranslationRepository productTranslationRepo;
+  private final CategoryTranslationRepository categoryTranslationRepo;
+
+  @Cacheable(value = "products", key = "'pt:' + #productId + ':' + #locale")
+  @Transactional(readOnly = true)
+  public Optional<ProductTranslation> getProductTranslation(Long productId, String locale) {
+    if (productId == null || locale == null || locale.isBlank()) {
+      return Optional.empty();
+    }
+    return productTranslationRepo.findByProductIdAndLocale(productId, locale);
+  }
+
+  @Cacheable(value = "products", key = "'ct:' + #categoryId + ':' + #locale")
+  @Transactional(readOnly = true)
+  public Optional<CategoryTranslation> getCategoryTranslation(Long categoryId, String locale) {
+    if (categoryId == null || locale == null || locale.isBlank()) {
+      return Optional.empty();
+    }
+    return categoryTranslationRepo.findByCategoryIdAndLocale(categoryId, locale);
+  }
+
+  /**
+   * Mutate the response in-place with the requested locale's translation if one
+   * exists. Returns the same instance for chaining.
+   */
+  public ProductResponse applyLocale(ProductResponse response, String locale) {
+    if (response == null || response.getProductId() == null || locale == null || locale.isBlank()) {
+      return response;
+    }
+    getProductTranslation(response.getProductId(), locale).ifPresent(t -> {
+      if (t.getName() != null) {
+        response.setProductName(t.getName());
+      }
+      if (t.getDescription() != null) {
+        response.setProductDescription(t.getDescription());
+      }
+    });
+    if (response.getCategoryId() != null) {
+      getCategoryTranslation(response.getCategoryId(), locale)
+          .ifPresent(ct -> {
+            if (ct.getName() != null) {
+              response.setCategoryName(ct.getName());
+            }
+          });
+    }
+    return response;
+  }
+
+  public List<ProductResponse> applyLocale(List<ProductResponse> responses, String locale) {
+    if (responses == null) {
+      return List.of();
+    }
+    responses.forEach(r -> applyLocale(r, locale));
+    return responses;
+  }
+
+  // ---------- Admin write APIs ----------
+  @CacheEvict(value = "products", allEntries = true)
+  @Transactional
+  public ProductTranslation upsertProduct(ProductTranslation t) {
+    return productTranslationRepo.save(t);
+  }
+
+  @CacheEvict(value = "products", allEntries = true)
+  @Transactional
+  public CategoryTranslation upsertCategory(CategoryTranslation t) {
+    return categoryTranslationRepo.save(t);
+  }
+}

--- a/src/main/java/com/xplaza/backend/cms/controller/CmsBlockController.java
+++ b/src/main/java/com/xplaza/backend/cms/controller/CmsBlockController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.cms.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.xplaza.backend.cms.domain.entity.CmsBlock;
+import com.xplaza.backend.cms.service.CmsBlockService;
+
+/**
+ * Public read endpoints + admin write endpoints for storefront CMS blocks.
+ */
+@RestController
+@RequestMapping("/api/v1/cms/blocks")
+@RequiredArgsConstructor
+@Tag(name = "CMS Blocks", description = "Static content blocks served to the storefront")
+public class CmsBlockController {
+
+  private final CmsBlockService service;
+
+  @Operation(summary = "Get an active CMS block by code (storefront-public)")
+  @GetMapping("/{code}")
+  public ResponseEntity<CmsBlock> get(
+      @PathVariable String code,
+      @RequestParam(required = false, defaultValue = "en") String locale) {
+    return service.getActive(code, locale)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @Operation(summary = "List all active CMS blocks")
+  @GetMapping
+  public ResponseEntity<List<CmsBlock>> list() {
+    return ResponseEntity.ok(service.listActive());
+  }
+
+  @Operation(summary = "Create or update a CMS block (admin)")
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<CmsBlock> save(@RequestBody @Valid CmsBlock block) {
+    return ResponseEntity.ok(service.save(block));
+  }
+
+  @Operation(summary = "Delete a CMS block (admin)")
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    service.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
+++ b/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
@@ -13,10 +13,13 @@ import lombok.*;
 
 /**
  * Storefront CMS block. Used for static content slots like the homepage hero
- * banner, footer copy, return policy etc. Lookup is by stable {@code code}.
+ * banner, footer copy, return policy etc. Lookup is by the composite
+ * {@code (code, locale)} key so the same {@code code} can ship a localised
+ * variant per supported locale.
  */
 @Entity
-@Table(name = "cms_blocks", uniqueConstraints = @UniqueConstraint(columnNames = "code"))
+@Table(name = "cms_blocks", uniqueConstraints = @UniqueConstraint(name = "uq_cms_blocks_code_locale", columnNames = {
+    "code", "locale" }))
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
+++ b/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.cms.domain.entity;
+
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Storefront CMS block. Used for static content slots like the homepage hero
+ * banner, footer copy, return policy etc. Lookup is by stable {@code code}.
+ */
+@Entity
+@Table(name = "cms_blocks", uniqueConstraints = @UniqueConstraint(columnNames = "code"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CmsBlock {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String code;
+
+  @Column(length = 255)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String body;
+
+  @Column(length = 10)
+  @Builder.Default
+  private String locale = "en";
+
+  @Column(name = "is_active")
+  @Builder.Default
+  private Boolean active = Boolean.TRUE;
+
+  @Column(name = "updated_at", nullable = false)
+  @Builder.Default
+  private Instant updatedAt = Instant.now();
+
+  @PreUpdate
+  void touch() {
+    this.updatedAt = Instant.now();
+  }
+}

--- a/src/main/java/com/xplaza/backend/cms/domain/repository/CmsBlockRepository.java
+++ b/src/main/java/com/xplaza/backend/cms/domain/repository/CmsBlockRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.cms.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.cms.domain.entity.CmsBlock;
+
+@Repository
+public interface CmsBlockRepository extends JpaRepository<CmsBlock, Long> {
+  Optional<CmsBlock> findByCodeAndLocaleAndActiveTrue(String code, String locale);
+
+  Optional<CmsBlock> findByCode(String code);
+
+  List<CmsBlock> findByActiveTrue();
+}

--- a/src/main/java/com/xplaza/backend/cms/service/CmsBlockService.java
+++ b/src/main/java/com/xplaza/backend/cms/service/CmsBlockService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.cms.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.cms.domain.entity.CmsBlock;
+import com.xplaza.backend.cms.domain.repository.CmsBlockRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CmsBlockService {
+
+  private final CmsBlockRepository repo;
+
+  @Cacheable(value = "cms-blocks", key = "#code + ':' + #locale")
+  @Transactional(readOnly = true)
+  public Optional<CmsBlock> getActive(String code, String locale) {
+    return repo.findByCodeAndLocaleAndActiveTrue(code, locale != null ? locale : "en");
+  }
+
+  @Transactional(readOnly = true)
+  public List<CmsBlock> listActive() {
+    return repo.findByActiveTrue();
+  }
+
+  @CacheEvict(value = "cms-blocks", allEntries = true)
+  public CmsBlock save(CmsBlock block) {
+    return repo.save(block);
+  }
+
+  @CacheEvict(value = "cms-blocks", allEntries = true)
+  public void delete(Long id) {
+    repo.deleteById(id);
+  }
+}

--- a/src/main/java/com/xplaza/backend/common/config/CacheConfig.java
+++ b/src/main/java/com/xplaza/backend/common/config/CacheConfig.java
@@ -28,7 +28,8 @@ public class CacheConfig implements CachingConfigurer {
   static final List<String> CACHE_NAMES = List.of(
       "products", "productById", "categories", "categoryById",
       "shops", "currencies", "taxRules", "customerSegments",
-      "homepageCampaigns", "deliveryCosts", "recommendations");
+      "homepageCampaigns", "deliveryCosts", "recommendations",
+      "priceLists", "cms-blocks", "tax");
 
   @Override
   @Bean

--- a/src/main/java/com/xplaza/backend/common/events/DomainEvent.java
+++ b/src/main/java/com/xplaza/backend/common/events/DomainEvent.java
@@ -40,6 +40,8 @@ public sealed interface DomainEvent permits
     DomainEvents.NotificationRequested,
     DomainEvents.GiftCardIssued,
     DomainEvents.SubscriptionCreated,
+    DomainEvents.SubscriptionRenewed,
+    DomainEvents.SubscriptionRenewalFailed,
     DomainEvents.VendorPayoutProcessed {
 
   UUID eventId();

--- a/src/main/java/com/xplaza/backend/common/events/DomainEvents.java
+++ b/src/main/java/com/xplaza/backend/common/events/DomainEvents.java
@@ -121,7 +121,7 @@ public final class DomainEvents {
   public record CartAbandoned(
       UUID eventId,
       Instant occurredAt,
-      Long cartId,
+      UUID cartId,
       Long customerId,
       String email
   ) implements DomainEvent {

--- a/src/main/java/com/xplaza/backend/common/events/DomainEvents.java
+++ b/src/main/java/com/xplaza/backend/common/events/DomainEvents.java
@@ -207,6 +207,27 @@ public final class DomainEvents {
   ) implements DomainEvent {
   }
 
+  public record SubscriptionRenewed(
+      UUID eventId,
+      Instant occurredAt,
+      Long subscriptionId,
+      Long customerId,
+      UUID orderId,
+      BigDecimal totalAmount,
+      String currency
+  ) implements DomainEvent {
+  }
+
+  public record SubscriptionRenewalFailed(
+      UUID eventId,
+      Instant occurredAt,
+      Long subscriptionId,
+      Long customerId,
+      int attemptNumber,
+      String reason
+  ) implements DomainEvent {
+  }
+
   public record VendorPayoutProcessed(
       UUID eventId,
       Instant occurredAt,

--- a/src/main/java/com/xplaza/backend/common/service/impl/MinioFileStorageService.java
+++ b/src/main/java/com/xplaza/backend/common/service/impl/MinioFileStorageService.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
@@ -45,6 +47,8 @@ public class MinioFileStorageService implements FileStorageService {
   }
 
   @Override
+  @CircuitBreaker(name = "minio")
+  @Retry(name = "minio")
   public String uploadFile(MultipartFile file) {
     validateFile(file);
     try {
@@ -96,6 +100,8 @@ public class MinioFileStorageService implements FileStorageService {
   }
 
   @Override
+  @CircuitBreaker(name = "minio")
+  @Retry(name = "minio")
   public void deleteFile(String fileUrl) {
     try {
       String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);

--- a/src/main/java/com/xplaza/backend/customer/controller/CustomerAuthController.java
+++ b/src/main/java/com/xplaza/backend/customer/controller/CustomerAuthController.java
@@ -21,6 +21,7 @@ import com.xplaza.backend.auth.dto.response.AuthenticationResponse;
 import com.xplaza.backend.common.util.ApiResponse;
 import com.xplaza.backend.customer.domain.entity.Customer;
 import com.xplaza.backend.customer.dto.CustomerRequest;
+import com.xplaza.backend.customer.dto.response.CustomerProfileResponse;
 import com.xplaza.backend.customer.service.CustomerService;
 
 @RestController
@@ -87,8 +88,8 @@ public class CustomerAuthController {
 
   @GetMapping("/me")
   @PreAuthorize("hasRole('CUSTOMER')")
-  public ResponseEntity<ApiResponse<Customer>> me(@AuthenticationPrincipal Customer customer) {
-    return ResponseEntity.ok(ApiResponse.ok(customer));
+  public ResponseEntity<ApiResponse<CustomerProfileResponse>> me(@AuthenticationPrincipal Customer customer) {
+    return ResponseEntity.ok(ApiResponse.ok(CustomerProfileResponse.from(customer)));
   }
 
   // ---------- Request DTOs ----------

--- a/src/main/java/com/xplaza/backend/customer/controller/CustomerGdprController.java
+++ b/src/main/java/com/xplaza/backend/customer/controller/CustomerGdprController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.xplaza.backend.common.util.ApiResponse;
 import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.customer.dto.response.CustomerProfileResponse;
 import com.xplaza.backend.customer.service.CustomerService;
 
 @RestController
@@ -30,8 +31,9 @@ public class CustomerGdprController {
 
   /** Right to access (GDPR Art. 15). */
   @GetMapping(value = "/export", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<ApiResponse<Customer>> export(@AuthenticationPrincipal Customer customer) {
-    return ResponseEntity.ok(ApiResponse.ok(customerService.exportCustomerData(customer.getCustomerId())));
+  public ResponseEntity<ApiResponse<CustomerProfileResponse>> export(@AuthenticationPrincipal Customer customer) {
+    Customer data = customerService.exportCustomerData(customer.getCustomerId());
+    return ResponseEntity.ok(ApiResponse.ok(CustomerProfileResponse.from(data)));
   }
 
   /**

--- a/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
+++ b/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
@@ -22,6 +22,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Table(name = "customers")
 @Entity
 @Getter
@@ -48,6 +50,7 @@ public class Customer implements UserDetails {
   private String email;
 
   @Column(nullable = false)
+  @JsonIgnore
   private String password;
 
   private String phoneNumber;
@@ -69,11 +72,15 @@ public class Customer implements UserDetails {
   private Instant emailVerifiedAt;
 
   // ---------- Account lockout ----------
+  // Hidden from JSON: leaking these aids credential-stuffing attackers in
+  // timing their next attempt window.
   @Column(name = "failed_login_attempts", nullable = false)
   @Builder.Default
+  @JsonIgnore
   private Integer failedLoginAttempts = 0;
 
   @Column(name = "locked_until")
+  @JsonIgnore
   private Instant lockedUntil;
 
   // ---------- MFA ----------
@@ -81,14 +88,21 @@ public class Customer implements UserDetails {
   @Builder.Default
   private Boolean mfaEnabled = false;
 
+  // The TOTP shared-secret. Exposing it would let anyone with a stolen
+  // session token also generate valid second-factor codes, completely
+  // defeating MFA — it must never leave the server.
   @Column(name = "mfa_secret", length = 200)
+  @JsonIgnore
   private String mfaSecret;
 
   // ---------- OAuth ----------
   @Column(name = "oauth_provider", length = 30)
   private String oauthProvider;
 
+  // The provider-specific subject identifier — treated as a credential and
+  // hidden from API responses to prevent account takeover via lookup tables.
   @Column(name = "oauth_subject", length = 200)
+  @JsonIgnore
   private String oauthSubject;
 
   // ---------- Loyalty ----------

--- a/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
+++ b/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
@@ -17,6 +17,7 @@ import lombok.*;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.envers.Audited;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,6 +31,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Builder
 @SQLDelete(sql = "UPDATE customers SET deleted_at = CURRENT_TIMESTAMP WHERE customer_id = ?")
 @SQLRestriction("deleted_at IS NULL")
+@Audited
 public class Customer implements UserDetails {
 
   @Id

--- a/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
+++ b/src/main/java/com/xplaza/backend/customer/domain/entity/Customer.java
@@ -15,6 +15,8 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,6 +28,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE customers SET deleted_at = CURRENT_TIMESTAMP WHERE customer_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Customer implements UserDetails {
 
   @Id
@@ -108,6 +112,9 @@ public class Customer implements UserDetails {
   // ---------- Lifecycle ----------
   private LocalDateTime createdAt;
   private LocalDateTime lastLoginAt;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 
   @PrePersist
   protected void onCreate() {

--- a/src/main/java/com/xplaza/backend/customer/dto/response/CustomerProfileResponse.java
+++ b/src/main/java/com/xplaza/backend/customer/dto/response/CustomerProfileResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.customer.dto.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import com.xplaza.backend.customer.domain.entity.Customer;
+
+/**
+ * Safe projection of {@link Customer} for endpoints that hand the customer's
+ * own profile back to them ({@code /me}, {@code /gdpr/export}, ...).
+ *
+ * <p>
+ * This DTO is the API contract for those endpoints — never return the JPA
+ * entity directly. It deliberately omits credential-grade fields
+ * ({@code password}, {@code mfaSecret}, {@code oauthSubject}) and
+ * security-state fields ({@code failedLoginAttempts}, {@code lockedUntil})
+ * because exposing them would let an attacker who hijacks a session also
+ * brute-force the password offline, generate valid TOTP codes, or time
+ * credential-stuffing windows.
+ */
+public record CustomerProfileResponse(
+    Long customerId,
+    String firstName,
+    String lastName,
+    String email,
+    String phoneNumber,
+    String role,
+    Boolean enabled,
+    Boolean emailVerified,
+    Instant emailVerifiedAt,
+    Boolean mfaEnabled,
+    String oauthProvider,
+    Long loyaltyPoints,
+    String loyaltyTier,
+    BigDecimal storeCredit,
+    Long customerGroupId,
+    String taxId,
+    LocalDateTime createdAt,
+    LocalDateTime lastLoginAt
+) {
+
+  public static CustomerProfileResponse from(Customer c) {
+    if (c == null) {
+      return null;
+    }
+    return new CustomerProfileResponse(
+        c.getCustomerId(),
+        c.getFirstName(),
+        c.getLastName(),
+        c.getEmail(),
+        c.getPhoneNumber(),
+        c.getRole(),
+        c.getEnabled(),
+        c.getEmailVerified(),
+        c.getEmailVerifiedAt(),
+        c.getMfaEnabled(),
+        c.getOauthProvider(),
+        c.getLoyaltyPoints(),
+        c.getLoyaltyTier(),
+        c.getStoreCredit(),
+        c.getCustomerGroupId(),
+        c.getTaxId(),
+        c.getCreatedAt(),
+        c.getLastLoginAt());
+  }
+}

--- a/src/main/java/com/xplaza/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/xplaza/backend/exception/GlobalExceptionHandler.java
@@ -161,6 +161,20 @@ public class GlobalExceptionHandler {
   }
 
   /**
+   * Handle authorization failures (403). Without this the default Spring Security
+   * AccessDeniedHandler turns every ownership-check violation into a 500 because
+   * our SecurityFilterChain doesn't install a handler.
+   */
+  @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+  public ResponseEntity<ApiResponse<Void>> handleAccessDenied(
+      org.springframework.security.access.AccessDeniedException ex) {
+    log.warn("Access denied: {}", ex.getMessage());
+    return ResponseEntity
+        .status(HttpStatus.FORBIDDEN)
+        .body(ApiResponse.error("ACCESS_DENIED", ex.getMessage()));
+  }
+
+  /**
    * Catch-all for unexpected errors (500)
    */
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/xplaza/backend/loyalty/service/LoyaltyService.java
+++ b/src/main/java/com/xplaza/backend/loyalty/service/LoyaltyService.java
@@ -10,10 +10,10 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.UUID;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -29,12 +29,29 @@ import com.xplaza.backend.customer.domain.repository.CustomerRepository;
  * tuned without redeploying.
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class LoyaltyService {
 
   private final CustomerRepository customerRepository;
   private final DomainEventPublisher eventPublisher;
+  /**
+   * Self-reference injected lazily so the {@link #on(DomainEvents.OrderPlaced)}
+   * listener can route through the Spring AOP proxy when calling
+   * {@link #accrue(Long, BigDecimal, java.util.UUID)}. A direct
+   * {@code this.accrue(...)} bypasses the proxy, which silently strips the
+   * {@code @Transactional} boundary and breaks {@link DomainEventPublisher}'s
+   * {@code Propagation.MANDATORY} requirement (silently losing the
+   * {@code LoyaltyPointsEarned} outbox event on every order).
+   */
+  private final LoyaltyService self;
+
+  public LoyaltyService(CustomerRepository customerRepository,
+      DomainEventPublisher eventPublisher,
+      @Lazy LoyaltyService self) {
+    this.customerRepository = customerRepository;
+    this.eventPublisher = eventPublisher;
+    this.self = self;
+  }
 
   @Value("${loyalty.points.earn-rate:1}")
   private long earnRate; // points per currency unit spent
@@ -90,9 +107,13 @@ public class LoyaltyService {
       return;
     }
     try {
-      accrue(event.customerId(), event.total(), event.orderId());
+      // Route through the proxy so @Transactional(accrue) is honoured and
+      // DomainEventPublisher.publish() finds the enclosing transaction it
+      // mandates.
+      self.accrue(event.customerId(), event.total(), event.orderId());
     } catch (Exception e) {
-      log.warn("Loyalty accrual failed for {}", event.orderId(), e);
+      log.error("Loyalty accrual failed for order {} (customer {}): {}",
+          event.orderId(), event.customerId(), e.getMessage(), e);
     }
   }
 }

--- a/src/main/java/com/xplaza/backend/loyalty/service/LoyaltyService.java
+++ b/src/main/java/com/xplaza/backend/loyalty/service/LoyaltyService.java
@@ -72,6 +72,28 @@ public class LoyaltyService {
     return points;
   }
 
+  /**
+   * Credit a fixed number of points to a customer with a caller-supplied
+   * {@code reason}. Used for non-order-derived grants (referral rewards,
+   * customer-service goodwill, etc.). Persists the balance and emits a single
+   * {@link DomainEvents.LoyaltyPointsEarned} event — callers must not publish
+   * their own event on top, otherwise the outbox double-counts the grant.
+   */
+  @Transactional
+  public long grantPoints(Long customerId, long points, String reason) {
+    if (points <= 0) {
+      return 0L;
+    }
+    var customer = customerRepository.findById(customerId).orElseThrow();
+    long newBalance = (customer.getLoyaltyPoints() == null ? 0L : customer.getLoyaltyPoints()) + points;
+    customer.setLoyaltyPoints(newBalance);
+    customer.setLoyaltyTier(determineTier(newBalance));
+    customerRepository.save(customer);
+    eventPublisher.publish(new DomainEvents.LoyaltyPointsEarned(
+        UUID.randomUUID(), Instant.now(), customerId, points, reason));
+    return points;
+  }
+
   @Transactional
   public BigDecimal redeem(Long customerId, long points, UUID orderId) {
     var customer = customerRepository.findById(customerId).orElseThrow();

--- a/src/main/java/com/xplaza/backend/marketing/controller/ReferralController.java
+++ b/src/main/java/com/xplaza/backend/marketing/controller/ReferralController.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.marketing.controller;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.marketing.domain.entity.Referral;
+import com.xplaza.backend.marketing.service.ReferralService;
+
+@RestController
+@RequestMapping("/api/v1/customer/referrals")
+@RequiredArgsConstructor
+@Tag(name = "Referrals", description = "Customer referral program")
+public class ReferralController {
+
+  private final ReferralService referralService;
+
+  @Operation(summary = "Send a referral invitation")
+  @PostMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Referral> createReferral(
+      @AuthenticationPrincipal Customer principal,
+      @RequestBody @org.springframework.validation.annotation.Validated CreateReferralRequest request) {
+    Referral referral = referralService.createReferral(principal.getCustomerId(), request.email());
+    return ResponseEntity.ok(referral);
+  }
+
+  @Operation(summary = "List my referrals")
+  @GetMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<List<Referral>> listReferrals(@AuthenticationPrincipal Customer principal) {
+    return ResponseEntity.ok(referralService.listReferrals(principal.getCustomerId()));
+  }
+
+  @Operation(summary = "Mark a referral code as accepted by the current customer")
+  @PostMapping("/accept/{code}")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Void> accept(@AuthenticationPrincipal Customer principal,
+      @PathVariable String code) {
+    referralService.markAccepted(code, principal.getCustomerId());
+    return ResponseEntity.noContent().build();
+  }
+
+  public record CreateReferralRequest(@NotNull @NotBlank @Email String email) {
+  }
+}

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
@@ -224,27 +224,177 @@ public class Campaign {
   }
 
   /**
-   * Calculate discount for a given subtotal.
+   * Calculate the cash discount for a flat subtotal. Backwards-compatible shim
+   * for callers that do not have shipping or line-item context. For percentage
+   * and fixed-amount campaigns this is exact; for FREE_SHIPPING and BOGO/BUNDLE
+   * the caller should use {@link #calculateDiscount(DiscountContext)} which can
+   * see shipping cost and individual lines.
    */
   public BigDecimal calculateDiscount(BigDecimal subtotal) {
+    return calculateDiscount(DiscountContext.of(subtotal));
+  }
+
+  /**
+   * Rich discount calculation for all campaign/discount types, using the pre-tax
+   * subtotal, the shipping cost and the cart line items the campaign targets.
+   * Returns the total cash value to subtract from the order.
+   *
+   * <p>
+   * Behaviour by type:
+   * <ul>
+   * <li>{@link DiscountType#PERCENTAGE}: percentage of subtotal.</li>
+   * <li>{@link DiscountType#FIXED_AMOUNT}: fixed cash discount.</li>
+   * <li>{@link DiscountType#FREE_SHIPPING}: returns the shipping cost so the
+   * checkout/cart maths zero out shipping for the buyer.</li>
+   * <li>{@link DiscountType#FREE_ITEM} combined with
+   * {@link CampaignType#BUY_X_GET_Y}: applies a BOGO calculation on the targeted
+   * SKUs (cheapest qualifying line is free per X bought).</li>
+   * <li>{@link CampaignType#BUNDLE}: requires every targeted product to be
+   * present in the cart; if so applies the campaign's discount value as a flat
+   * amount (or {@code maxDiscount}, whichever is smaller).</li>
+   * </ul>
+   * Always honours {@link #minPurchase} and {@link #maxDiscount}.
+   */
+  public BigDecimal calculateDiscount(DiscountContext ctx) {
+    BigDecimal subtotal = ctx.subtotal();
+    if (subtotal == null || subtotal.signum() <= 0) {
+      return BigDecimal.ZERO;
+    }
     if (minPurchase != null && subtotal.compareTo(minPurchase) < 0) {
       return BigDecimal.ZERO;
     }
 
-    BigDecimal discount;
-    if (discountType == DiscountType.PERCENTAGE) {
-      discount = subtotal.multiply(discountValue).divide(BigDecimal.valueOf(100));
-    } else if (discountType == DiscountType.FIXED_AMOUNT) {
-      discount = discountValue;
-    } else {
-      return BigDecimal.ZERO;
+    BigDecimal discount = switch (effectiveDiscountType()) {
+    case PERCENTAGE -> percentageDiscount(subtotal);
+    case FIXED_AMOUNT -> discountValue == null ? BigDecimal.ZERO : discountValue;
+    case FREE_SHIPPING -> ctx.shippingCost() == null ? BigDecimal.ZERO : ctx.shippingCost();
+    case FREE_ITEM -> bogoDiscount(ctx.lineItems());
+    };
+
+    if (type == CampaignType.BUNDLE) {
+      discount = bundleDiscount(ctx.lineItems());
     }
 
     if (maxDiscount != null && discount.compareTo(maxDiscount) > 0) {
       discount = maxDiscount;
     }
+    return discount.max(BigDecimal.ZERO);
+  }
 
-    return discount;
+  /**
+   * Projects {@link CampaignType} onto {@link DiscountType} when the type is
+   * implicit (e.g. a {@code FREE_SHIPPING} campaign with no explicit
+   * {@code discountType}).
+   */
+  private DiscountType effectiveDiscountType() {
+    if (discountType != null) {
+      return discountType;
+    }
+    return switch (type) {
+    case FREE_SHIPPING -> DiscountType.FREE_SHIPPING;
+    case BUY_X_GET_Y -> DiscountType.FREE_ITEM;
+    case PERCENTAGE_DISCOUNT, FLASH_SALE, SEASONAL, CLEARANCE, LOYALTY, FIRST_PURCHASE -> DiscountType.PERCENTAGE;
+    case FIXED_DISCOUNT, BUNDLE -> DiscountType.FIXED_AMOUNT;
+    };
+  }
+
+  private BigDecimal percentageDiscount(BigDecimal subtotal) {
+    if (discountValue == null) {
+      return BigDecimal.ZERO;
+    }
+    return subtotal.multiply(discountValue).divide(java.math.BigDecimal.valueOf(100), 2,
+        java.math.RoundingMode.HALF_UP);
+  }
+
+  /**
+   * BOGO / Buy-X-Get-Y. The {@code discountValue} field holds the X (number of
+   * items the customer must buy to get one free). Picks the cheapest qualifying
+   * line across the cart so the buyer always gets the most-affordable freebie.
+   */
+  private BigDecimal bogoDiscount(List<DiscountLine> lines) {
+    if (lines == null || lines.isEmpty()) {
+      return BigDecimal.ZERO;
+    }
+    int x = (discountValue == null ? 1 : discountValue.intValue());
+    if (x < 1) {
+      x = 1;
+    }
+    int totalQty = lines.stream().mapToInt(DiscountLine::quantity).sum();
+    int freebies = totalQty / (x + 1);
+    if (freebies <= 0) {
+      return BigDecimal.ZERO;
+    }
+    BigDecimal cheapest = lines.stream()
+        .map(DiscountLine::unitPrice)
+        .min(BigDecimal::compareTo)
+        .orElse(BigDecimal.ZERO);
+    return cheapest.multiply(BigDecimal.valueOf(freebies));
+  }
+
+  /**
+   * BUNDLE. Every product id in {@code targetProducts} (CSV) must be present with
+   * quantity ≥ 1; if so the bundle discount equals {@code discountValue}.
+   */
+  private BigDecimal bundleDiscount(List<DiscountLine> lines) {
+    if (discountValue == null || targetProducts == null || targetProducts.isBlank()) {
+      return BigDecimal.ZERO;
+    }
+    var requiredIds = parseTargetProductIds();
+    if (requiredIds.isEmpty()) {
+      return BigDecimal.ZERO;
+    }
+    if (lines == null || lines.isEmpty()) {
+      return BigDecimal.ZERO;
+    }
+    var present = new java.util.HashSet<Long>();
+    for (var l : lines) {
+      if (l.quantity() > 0) {
+        present.add(l.productId());
+      }
+    }
+    return present.containsAll(requiredIds) ? discountValue : BigDecimal.ZERO;
+  }
+
+  private List<Long> parseTargetProductIds() {
+    var out = new ArrayList<Long>();
+    for (var raw : targetProducts.split(",")) {
+      var s = raw.trim();
+      if (s.isEmpty()) {
+        continue;
+      }
+      try {
+        out.add(Long.parseLong(s));
+      } catch (NumberFormatException ignored) {
+        // skip malformed entries
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Cart context required to calculate any campaign type. Only the
+   * {@code subtotal} is mandatory; other fields default to neutral values when
+   * absent so legacy callers using {@link #calculateDiscount(BigDecimal)} get the
+   * previous behaviour.
+   */
+  public record DiscountContext(
+      BigDecimal subtotal,
+      BigDecimal shippingCost,
+      List<DiscountLine> lineItems
+  ) {
+    public static DiscountContext of(BigDecimal subtotal) {
+      return new DiscountContext(subtotal, BigDecimal.ZERO, List.of());
+    }
+  }
+
+  /**
+   * Lightweight projection of a cart line — just what BOGO/BUNDLE need.
+   */
+  public record DiscountLine(
+      Long productId,
+      int quantity,
+      BigDecimal unitPrice
+  ) {
   }
 
   /**

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
@@ -310,21 +310,40 @@ public class Campaign {
    * BOGO / Buy-X-Get-Y. The {@code discountValue} field holds the X (number of
    * items the customer must buy to get one free). Picks the cheapest qualifying
    * line across the cart so the buyer always gets the most-affordable freebie.
+   *
+   * <p>
+   * Respects {@link #targetProducts}: when the campaign is scoped to specific
+   * SKUs, only those cart lines are counted for the qty threshold <em>and</em> as
+   * potential freebies. Lines outside the campaign scope are ignored so unrelated
+   * products can never trip the BOGO or serve as the freebie.
    */
   private BigDecimal bogoDiscount(List<DiscountLine> lines) {
     if (lines == null || lines.isEmpty()) {
       return BigDecimal.ZERO;
     }
+    List<DiscountLine> eligible = lines;
+    if (targetProducts != null && !targetProducts.isBlank()) {
+      var targetIds = new java.util.HashSet<>(parseTargetProductIds());
+      if (targetIds.isEmpty()) {
+        return BigDecimal.ZERO;
+      }
+      eligible = lines.stream()
+          .filter(l -> l.productId() != null && targetIds.contains(l.productId()))
+          .toList();
+      if (eligible.isEmpty()) {
+        return BigDecimal.ZERO;
+      }
+    }
     int x = (discountValue == null ? 1 : discountValue.intValue());
     if (x < 1) {
       x = 1;
     }
-    int totalQty = lines.stream().mapToInt(DiscountLine::quantity).sum();
+    int totalQty = eligible.stream().mapToInt(DiscountLine::quantity).sum();
     int freebies = totalQty / (x + 1);
     if (freebies <= 0) {
       return BigDecimal.ZERO;
     }
-    BigDecimal cheapest = lines.stream()
+    BigDecimal cheapest = eligible.stream()
         .map(DiscountLine::unitPrice)
         .min(BigDecimal::compareTo)
         .orElse(BigDecimal.ZERO);

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/Referral.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/Referral.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.marketing.domain.entity;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Referral record. A customer (the {@code referrer}) sends an invitation to an
+ * email address; once that referee registers and places their first order the
+ * referral is marked {@code REWARDED} and the referrer is credited.
+ */
+@Entity
+@Table(name = "referrals", indexes = {
+    @Index(name = "idx_referrals_referrer", columnList = "referrer_id"),
+    @Index(name = "idx_referrals_email", columnList = "referee_email")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Referral {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "referrer_id", nullable = false)
+  private Long referrerId;
+
+  @Column(name = "referee_email", nullable = false, length = 255)
+  private String refereeEmail;
+
+  @Column(name = "referee_id")
+  private Long refereeId;
+
+  @Column(name = "code", nullable = false, unique = true, length = 40)
+  private String code;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  @Builder.Default
+  private ReferralStatus status = ReferralStatus.PENDING;
+
+  @Column(name = "rewarded_at")
+  private Instant rewardedAt;
+
+  @Column(name = "reward_amount", precision = 14, scale = 2)
+  private BigDecimal rewardAmount;
+
+  @Column(name = "created_at", nullable = false)
+  @Builder.Default
+  private Instant createdAt = Instant.now();
+
+  public enum ReferralStatus {
+    PENDING,
+    ACCEPTED,
+    REWARDED,
+    EXPIRED,
+    CANCELLED
+  }
+}

--- a/src/main/java/com/xplaza/backend/marketing/domain/repository/ReferralRepository.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/repository/ReferralRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.marketing.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.marketing.domain.entity.Referral;
+
+@Repository
+public interface ReferralRepository extends JpaRepository<Referral, Long> {
+  Optional<Referral> findByCode(String code);
+
+  List<Referral> findByReferrerId(Long referrerId);
+
+  Optional<Referral> findByRefereeEmailIgnoreCaseAndStatus(String email, Referral.ReferralStatus status);
+}

--- a/src/main/java/com/xplaza/backend/marketing/domain/repository/ReferralRepository.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/repository/ReferralRepository.java
@@ -20,4 +20,13 @@ public interface ReferralRepository extends JpaRepository<Referral, Long> {
   List<Referral> findByReferrerId(Long referrerId);
 
   Optional<Referral> findByRefereeEmailIgnoreCaseAndStatus(String email, Referral.ReferralStatus status);
+
+  /**
+   * Indexed lookup for the {@code OrderPlaced} listener. An order placed by
+   * {@code refereeId} triggers the referrer reward, so this query runs on every
+   * order and must be an indexed hit (idx_referrals_referee) — a
+   * {@code findAll()} scan here would degrade to O(N) on the referrals table as
+   * the program grows.
+   */
+  Optional<Referral> findFirstByRefereeIdAndStatus(Long refereeId, Referral.ReferralStatus status);
 }

--- a/src/main/java/com/xplaza/backend/marketing/service/CampaignService.java
+++ b/src/main/java/com/xplaza/backend/marketing/service/CampaignService.java
@@ -209,6 +209,16 @@ public class CampaignService {
    */
   @Transactional(readOnly = true)
   public BigDecimal validateCoupon(String code, BigDecimal subtotal, int customerUseCount) {
+    return validateCoupon(code, Campaign.DiscountContext.of(subtotal), customerUseCount);
+  }
+
+  /**
+   * Validate coupon against a richer cart context so BOGO/FREE_SHIPPING/BUNDLE
+   * campaigns calculate correctly. Used by checkout when shipping cost and cart
+   * line items are known.
+   */
+  @Transactional(readOnly = true)
+  public BigDecimal validateCoupon(String code, Campaign.DiscountContext ctx, int customerUseCount) {
     Campaign campaign = campaignRepository.findByCode(code)
         .orElseThrow(() -> new IllegalArgumentException("Campaign not found: " + code));
 
@@ -224,7 +234,7 @@ public class CampaignService {
       throw new IllegalStateException("Customer has reached usage limit for this campaign");
     }
 
-    return campaign.calculateDiscount(subtotal);
+    return campaign.calculateDiscount(ctx);
   }
 
   /**

--- a/src/main/java/com/xplaza/backend/marketing/service/ReferralService.java
+++ b/src/main/java/com/xplaza/backend/marketing/service/ReferralService.java
@@ -9,7 +9,6 @@ import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.xplaza.backend.common.events.DomainEventPublisher;
 import com.xplaza.backend.common.events.DomainEvents;
 import com.xplaza.backend.loyalty.service.LoyaltyService;
 import com.xplaza.backend.marketing.domain.entity.Referral;
@@ -43,7 +41,6 @@ public class ReferralService {
   private static final String ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
 
   private final ReferralRepository referralRepository;
-  private final DomainEventPublisher eventPublisher;
   private final LoyaltyService loyaltyService;
 
   @Value("${referral.reward-amount:10.00}")
@@ -88,8 +85,8 @@ public class ReferralService {
 
   /**
    * The referee's first order triggers the reward. We rely on the transactional
-   * outbox so the credit is durable even if the listener crashes before
-   * settlement.
+   * outbox (inside {@link LoyaltyService#grantPoints}) so the credit is durable
+   * even if the listener crashes before settlement.
    */
   @Async
   @EventListener
@@ -98,26 +95,29 @@ public class ReferralService {
     if (event.customerId() == null) {
       return;
     }
-    referralRepository.findAll().stream()
-        .filter(r -> r.getStatus() == Referral.ReferralStatus.ACCEPTED
-            && event.customerId().equals(r.getRefereeId()))
-        .findFirst()
+    referralRepository
+        .findFirstByRefereeIdAndStatus(event.customerId(), Referral.ReferralStatus.ACCEPTED)
         .ifPresent(ref -> reward(ref, event));
   }
 
   private void reward(Referral ref, DomainEvents.OrderPlaced event) {
     try {
-      loyaltyService.accrue(ref.getReferrerId(), rewardAmount.multiply(BigDecimal.valueOf(10)), event.orderId());
+      // Single source of truth for the grant: LoyaltyService persists the
+      // points and publishes LoyaltyPointsEarned. We do NOT publish our own
+      // event on top — that would double-count the reward in the outbox.
+      loyaltyService.grantPoints(ref.getReferrerId(), rewardPoints, "referral:" + ref.getCode());
     } catch (Exception e) {
-      log.warn("Failed to credit referral loyalty points for referrer {}: {}", ref.getReferrerId(), e.toString());
+      log.error("Failed to credit referral loyalty points for referrer {} (order {}): {}",
+          ref.getReferrerId(), event.orderId(), e.toString(), e);
+      // Do not mark the referral as REWARDED if we could not credit the
+      // points; the scheduler-driven retry path (future iteration) will pick
+      // up ACCEPTED referrals and try again.
+      return;
     }
     ref.setStatus(Referral.ReferralStatus.REWARDED);
     ref.setRewardedAt(Instant.now());
     ref.setRewardAmount(rewardAmount);
     referralRepository.save(ref);
-    eventPublisher.publish(new DomainEvents.LoyaltyPointsEarned(
-        UUID.randomUUID(), Instant.now(), ref.getReferrerId(), rewardPoints,
-        "referral:" + ref.getCode()));
   }
 
   private String generateCode() {

--- a/src/main/java/com/xplaza/backend/marketing/service/ReferralService.java
+++ b/src/main/java/com/xplaza/backend/marketing/service/ReferralService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.marketing.service;
+
+import java.math.BigDecimal;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.common.events.DomainEventPublisher;
+import com.xplaza.backend.common.events.DomainEvents;
+import com.xplaza.backend.loyalty.service.LoyaltyService;
+import com.xplaza.backend.marketing.domain.entity.Referral;
+import com.xplaza.backend.marketing.domain.repository.ReferralRepository;
+
+/**
+ * End-to-end referral program. The {@code referrer} invites someone via
+ * {@link #createReferral(Long, String)}; the system mints a unique short code
+ * and (in a future iteration) emails a deep link to the referee. When the
+ * referee registers, {@link #markAccepted(String, Long)} ties the customer to
+ * the referral; their first order then triggers {@link #onOrderPlaced} which
+ * credits the referrer with loyalty points and a small store credit.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReferralService {
+
+  private static final SecureRandom RNG = new SecureRandom();
+  private static final String ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+  private final ReferralRepository referralRepository;
+  private final DomainEventPublisher eventPublisher;
+  private final LoyaltyService loyaltyService;
+
+  @Value("${referral.reward-amount:10.00}")
+  private BigDecimal rewardAmount;
+
+  @Value("${referral.reward-points:500}")
+  private long rewardPoints;
+
+  @Transactional
+  public Referral createReferral(Long referrerId, String refereeEmail) {
+    var existing = referralRepository
+        .findByRefereeEmailIgnoreCaseAndStatus(refereeEmail, Referral.ReferralStatus.PENDING);
+    if (existing.isPresent()) {
+      return existing.get();
+    }
+    var ref = Referral.builder()
+        .referrerId(referrerId)
+        .refereeEmail(refereeEmail.toLowerCase())
+        .code(generateCode())
+        .status(Referral.ReferralStatus.PENDING)
+        .build();
+    return referralRepository.save(ref);
+  }
+
+  @Transactional(readOnly = true)
+  public List<Referral> listReferrals(Long referrerId) {
+    return referralRepository.findByReferrerId(referrerId);
+  }
+
+  @Transactional
+  public void markAccepted(String code, Long refereeCustomerId) {
+    var ref = referralRepository.findByCode(code)
+        .orElseThrow(() -> new IllegalArgumentException("Unknown referral code: " + code));
+    if (ref.getStatus() != Referral.ReferralStatus.PENDING) {
+      log.debug("Referral {} already in state {}; ignoring accept", code, ref.getStatus());
+      return;
+    }
+    ref.setRefereeId(refereeCustomerId);
+    ref.setStatus(Referral.ReferralStatus.ACCEPTED);
+    referralRepository.save(ref);
+  }
+
+  /**
+   * The referee's first order triggers the reward. We rely on the transactional
+   * outbox so the credit is durable even if the listener crashes before
+   * settlement.
+   */
+  @Async
+  @EventListener
+  @Transactional
+  public void onOrderPlaced(DomainEvents.OrderPlaced event) {
+    if (event.customerId() == null) {
+      return;
+    }
+    referralRepository.findAll().stream()
+        .filter(r -> r.getStatus() == Referral.ReferralStatus.ACCEPTED
+            && event.customerId().equals(r.getRefereeId()))
+        .findFirst()
+        .ifPresent(ref -> reward(ref, event));
+  }
+
+  private void reward(Referral ref, DomainEvents.OrderPlaced event) {
+    try {
+      loyaltyService.accrue(ref.getReferrerId(), rewardAmount.multiply(BigDecimal.valueOf(10)), event.orderId());
+    } catch (Exception e) {
+      log.warn("Failed to credit referral loyalty points for referrer {}: {}", ref.getReferrerId(), e.toString());
+    }
+    ref.setStatus(Referral.ReferralStatus.REWARDED);
+    ref.setRewardedAt(Instant.now());
+    ref.setRewardAmount(rewardAmount);
+    referralRepository.save(ref);
+    eventPublisher.publish(new DomainEvents.LoyaltyPointsEarned(
+        UUID.randomUUID(), Instant.now(), ref.getReferrerId(), rewardPoints,
+        "referral:" + ref.getCode()));
+  }
+
+  private String generateCode() {
+    var sb = new StringBuilder(8);
+    for (int i = 0; i < 8; i++) {
+      sb.append(ALPHABET.charAt(RNG.nextInt(ALPHABET.length())));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/xplaza/backend/notification/controller/PushTokenController.java
+++ b/src/main/java/com/xplaza/backend/notification/controller/PushTokenController.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.notification.controller;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.notification.domain.entity.PushToken;
+import com.xplaza.backend.notification.service.PushNotificationService;
+
+/**
+ * Customer-facing endpoints for managing FCM/APNs device tokens. Auth is
+ * enforced via {@code ROLE_CUSTOMER}; the token is always written against the
+ * authenticated principal so a malicious client cannot register a push token
+ * for someone else.
+ */
+@RestController
+@RequestMapping("/api/v1/push-tokens")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('CUSTOMER')")
+@Tag(name = "Push Tokens", description = "Register / revoke device push tokens")
+public class PushTokenController {
+
+  private final PushNotificationService pushService;
+
+  @Operation(summary = "Register or refresh the current device's push token")
+  @PostMapping("/register")
+  public ResponseEntity<PushToken> register(
+      @RequestParam PushToken.Platform platform,
+      @RequestParam @NotBlank String token,
+      @RequestParam(required = false) String deviceId) {
+    Long customerId = currentCustomerId();
+    return ResponseEntity.ok(pushService.registerToken(customerId, platform, token, deviceId));
+  }
+
+  @Operation(summary = "Unregister a device push token (e.g. on sign-out)")
+  @DeleteMapping
+  public ResponseEntity<Map<String, String>> unregister(@RequestParam @NotBlank String token) {
+    pushService.unregisterToken(token);
+    return ResponseEntity.ok(Map.of("status", "ok"));
+  }
+
+  @Operation(summary = "List the authenticated customer's registered tokens")
+  @GetMapping
+  public ResponseEntity<List<PushToken>> list() {
+    return ResponseEntity.ok(pushService.tokensForCustomer(currentCustomerId()));
+  }
+
+  private static Long currentCustomerId() {
+    Principal p = (Principal) SecurityContextHolder.getContext().getAuthentication();
+    if (p instanceof org.springframework.security.core.Authentication auth
+        && auth.getPrincipal() instanceof Customer c) {
+      return c.getCustomerId();
+    }
+    throw new IllegalStateException("No authenticated customer");
+  }
+}

--- a/src/main/java/com/xplaza/backend/notification/controller/PushTokenController.java
+++ b/src/main/java/com/xplaza/backend/notification/controller/PushTokenController.java
@@ -52,7 +52,7 @@ public class PushTokenController {
   @Operation(summary = "Unregister a device push token (e.g. on sign-out)")
   @DeleteMapping
   public ResponseEntity<Map<String, String>> unregister(@RequestParam @NotBlank String token) {
-    pushService.unregisterToken(token);
+    pushService.unregisterToken(currentCustomerId(), token);
     return ResponseEntity.ok(Map.of("status", "ok"));
   }
 

--- a/src/main/java/com/xplaza/backend/notification/domain/entity/PushToken.java
+++ b/src/main/java/com/xplaza/backend/notification/domain/entity/PushToken.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.notification.domain.entity;
+
+import java.time.Instant;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * A device push token registered by a customer for FCM (Android / web) or APNs
+ * (iOS). The notification worker fans out via {@code platform}.
+ */
+@Entity
+@Table(name = "push_tokens", uniqueConstraints = @UniqueConstraint(columnNames = "token"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PushToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "customer_id", nullable = false)
+  private Long customerId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 10)
+  private Platform platform;
+
+  @Column(nullable = false, length = 500)
+  private String token;
+
+  @Column(name = "device_id", length = 120)
+  private String deviceId;
+
+  @Column(name = "created_at", nullable = false)
+  @Builder.Default
+  private Instant createdAt = Instant.now();
+
+  @Column(name = "last_seen_at", nullable = false)
+  @Builder.Default
+  private Instant lastSeenAt = Instant.now();
+
+  public enum Platform {
+    ANDROID,
+    IOS,
+    WEB
+  }
+}

--- a/src/main/java/com/xplaza/backend/notification/domain/repository/PushTokenRepository.java
+++ b/src/main/java/com/xplaza/backend/notification/domain/repository/PushTokenRepository.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.notification.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.notification.domain.entity.PushToken;
+
+@Repository
+public interface PushTokenRepository extends JpaRepository<PushToken, Long> {
+  Optional<PushToken> findByToken(String token);
+
+  List<PushToken> findByCustomerId(Long customerId);
+
+  void deleteByToken(String token);
+}

--- a/src/main/java/com/xplaza/backend/notification/service/EmailService.java
+++ b/src/main/java/com/xplaza/backend/notification/service/EmailService.java
@@ -5,9 +5,13 @@
 
 package com.xplaza.backend.notification.service;
 
+import java.util.Map;
+
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,25 +30,47 @@ public class EmailService {
   private final JavaMailSender mailSender;
   private final TemplateEngine templateEngine;
 
+  /**
+   * Generic plaintext-into-html-template send. Kept for backwards compatibility;
+   * new transactional flows should call
+   * {@link #sendTemplate(String, String, String, Map)} so the per-event Thymeleaf
+   * template is selected.
+   */
   @Async
+  @CircuitBreaker(name = "mail")
+  @Retry(name = "mail")
   public void sendEmail(String to, String subject, String text) {
+    sendTemplate(to, subject, "email-template",
+        Map.of("title", subject, "message", text));
+  }
+
+  /**
+   * Render the given Thymeleaf template with the supplied model and send the
+   * result as an HTML email. The Thymeleaf templates live under
+   * {@code src/main/resources/templates}: order-confirmation, order-shipped,
+   * order-delivered, abandoned-cart, password-reset, invoice etc.
+   */
+  @Async
+  @CircuitBreaker(name = "mail")
+  @Retry(name = "mail")
+  public void sendTemplate(String to, String subject, String template, Map<String, Object> model) {
     try {
       MimeMessage mimeMessage = mailSender.createMimeMessage();
       MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
 
       Context context = new Context();
-      context.setVariable("title", subject);
-      context.setVariable("message", text);
-
-      String htmlContent = templateEngine.process("email-template", context);
+      if (model != null) {
+        model.forEach(context::setVariable);
+      }
+      String htmlContent = templateEngine.process(template, context);
 
       helper.setTo(to);
       helper.setSubject(subject);
-      helper.setText(htmlContent, true); // true = isHtml
+      helper.setText(htmlContent, true);
       helper.setFrom("noreply@xplaza.com");
 
       mailSender.send(mimeMessage);
-      log.info("HTML Email sent to {}", to);
+      log.info("HTML Email '{}' (template={}) sent to {}", subject, template, to);
     } catch (MessagingException e) {
       log.error("Failed to send HTML email to {}", to, e);
     }

--- a/src/main/java/com/xplaza/backend/notification/service/PushNotificationService.java
+++ b/src/main/java/com/xplaza/backend/notification/service/PushNotificationService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.notification.service;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.notification.domain.entity.PushToken;
+import com.xplaza.backend.notification.domain.repository.PushTokenRepository;
+
+/**
+ * Push-notification dispatcher. The intent is for this class to be the *only*
+ * place in the codebase that knows about FCM/APNs SDK details, so swapping
+ * providers is local. While the credentials are not yet wired (they live in the
+ * deployment secrets manager), the dispatcher is functional from the
+ * application's point of view: tokens get registered, opt-in is honoured, and
+ * each call is logged so operators can confirm the flow end-to-end.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PushNotificationService {
+
+  private final PushTokenRepository tokenRepo;
+
+  @Value("${push.fcm.enabled:false}")
+  private boolean fcmEnabled;
+
+  @Value("${push.apns.enabled:false}")
+  private boolean apnsEnabled;
+
+  /**
+   * Idempotently register or refresh a push token for a customer.
+   */
+  @Transactional
+  public PushToken registerToken(Long customerId, PushToken.Platform platform, String token, String deviceId) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException("Token must not be blank");
+    }
+    return tokenRepo.findByToken(token)
+        .map(existing -> {
+          existing.setCustomerId(customerId);
+          existing.setPlatform(platform);
+          existing.setDeviceId(deviceId);
+          existing.setLastSeenAt(Instant.now());
+          return tokenRepo.save(existing);
+        })
+        .orElseGet(() -> tokenRepo.save(PushToken.builder()
+            .customerId(customerId)
+            .platform(platform)
+            .token(token)
+            .deviceId(deviceId)
+            .createdAt(Instant.now())
+            .lastSeenAt(Instant.now())
+            .build()));
+  }
+
+  @Transactional
+  public void unregisterToken(String token) {
+    tokenRepo.findByToken(token).ifPresent(tokenRepo::delete);
+  }
+
+  @Transactional(readOnly = true)
+  public List<PushToken> tokensForCustomer(Long customerId) {
+    return tokenRepo.findByCustomerId(customerId);
+  }
+
+  /**
+   * Send a push notification to all of a customer's registered devices. Always
+   * asynchronous so transactional callers (e.g. order placement) are not delayed
+   * by network round-trips to FCM/APNs.
+   */
+  @Async
+  public void sendToCustomer(Long customerId, String title, String body) {
+    var tokens = tokensForCustomer(customerId);
+    if (tokens.isEmpty()) {
+      log.debug("No push tokens for customer {}, skipping push '{}'", customerId, title);
+      return;
+    }
+    for (PushToken pt : tokens) {
+      dispatch(pt, title, body);
+    }
+  }
+
+  private void dispatch(PushToken token, String title, String body) {
+    switch (token.getPlatform()) {
+    case ANDROID, WEB -> {
+      if (fcmEnabled) {
+        // TODO: integrate Firebase Admin SDK; intentionally left out of OSS
+        // build because credentials are deployment-specific.
+        log.info("[FCM] -> token={} title='{}' body='{}'", redact(token.getToken()), title, body);
+      } else {
+        log.debug("FCM disabled, skipping push to token {}", redact(token.getToken()));
+      }
+    }
+    case IOS -> {
+      if (apnsEnabled) {
+        // TODO: integrate Pushy or apns-http2 client.
+        log.info("[APNs] -> token={} title='{}' body='{}'", redact(token.getToken()), title, body);
+      } else {
+        log.debug("APNs disabled, skipping push to token {}", redact(token.getToken()));
+      }
+    }
+    default -> log.warn("Unknown platform {} for token {}", token.getPlatform(), token.getId());
+    }
+  }
+
+  private static String redact(String token) {
+    if (token == null || token.length() < 8) {
+      return "***";
+    }
+    return token.substring(0, 4) + "..." + token.substring(token.length() - 4);
+  }
+}

--- a/src/main/java/com/xplaza/backend/notification/service/PushNotificationService.java
+++ b/src/main/java/com/xplaza/backend/notification/service/PushNotificationService.java
@@ -42,33 +42,59 @@ public class PushNotificationService {
 
   /**
    * Idempotently register or refresh a push token for a customer.
+   *
+   * <p>
+   * If the token value already exists in the database, the existing row is only
+   * refreshed when it belongs to the <em>same</em> customer. A leaked or guessed
+   * token cannot be silently re-associated to a different account — the call
+   * fails with {@link org.springframework.security.access.AccessDeniedException}
+   * so operators can detect the attempt and rotate/ban the token.
    */
   @Transactional
   public PushToken registerToken(Long customerId, PushToken.Platform platform, String token, String deviceId) {
     if (token == null || token.isBlank()) {
       throw new IllegalArgumentException("Token must not be blank");
     }
-    return tokenRepo.findByToken(token)
-        .map(existing -> {
-          existing.setCustomerId(customerId);
-          existing.setPlatform(platform);
-          existing.setDeviceId(deviceId);
-          existing.setLastSeenAt(Instant.now());
-          return tokenRepo.save(existing);
-        })
-        .orElseGet(() -> tokenRepo.save(PushToken.builder()
-            .customerId(customerId)
-            .platform(platform)
-            .token(token)
-            .deviceId(deviceId)
-            .createdAt(Instant.now())
-            .lastSeenAt(Instant.now())
-            .build()));
+    if (customerId == null) {
+      throw new IllegalArgumentException("customerId is required");
+    }
+    var existing = tokenRepo.findByToken(token).orElse(null);
+    if (existing != null) {
+      if (!customerId.equals(existing.getCustomerId())) {
+        log.warn("Rejecting push token re-registration: token already bound to a different customer "
+            + "(attemptedBy={}, tokenPrefix={})", customerId, redact(token));
+        throw new org.springframework.security.access.AccessDeniedException(
+            "Push token is already registered to a different customer");
+      }
+      existing.setPlatform(platform);
+      existing.setDeviceId(deviceId);
+      existing.setLastSeenAt(Instant.now());
+      return tokenRepo.save(existing);
+    }
+    return tokenRepo.save(PushToken.builder()
+        .customerId(customerId)
+        .platform(platform)
+        .token(token)
+        .deviceId(deviceId)
+        .createdAt(Instant.now())
+        .lastSeenAt(Instant.now())
+        .build());
   }
 
+  /**
+   * Revoke a push token on behalf of the currently authenticated customer. Only
+   * deletes when the token's {@code customer_id} matches; other customers' tokens
+   * are ignored so an attacker who learns a token value cannot revoke someone
+   * else's device.
+   */
   @Transactional
-  public void unregisterToken(String token) {
-    tokenRepo.findByToken(token).ifPresent(tokenRepo::delete);
+  public void unregisterToken(Long customerId, String token) {
+    if (customerId == null || token == null || token.isBlank()) {
+      return;
+    }
+    tokenRepo.findByToken(token)
+        .filter(t -> customerId.equals(t.getCustomerId()))
+        .ifPresent(tokenRepo::delete);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/xplaza/backend/order/controller/CustomerOrderController.java
+++ b/src/main/java/com/xplaza/backend/order/controller/CustomerOrderController.java
@@ -42,6 +42,13 @@ public class CustomerOrderController {
         .orElse(ResponseEntity.notFound().build());
   }
 
+  @Operation(summary = "List per-vendor child orders for a parent order id")
+  @GetMapping("/{orderId}/children")
+  public ResponseEntity<List<CustomerOrder>> getChildOrders(
+      @Parameter(description = "Parent order id") @PathVariable UUID orderId) {
+    return ResponseEntity.ok(customerOrderService.getChildOrders(orderId));
+  }
+
   @Operation(summary = "Get order by order number")
   @GetMapping("/number/{orderNumber}")
   public ResponseEntity<CustomerOrder> getOrderByNumber(

--- a/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
@@ -61,6 +61,14 @@ public class CustomerOrder {
   @Column(name = "cart_id")
   private UUID cartId;
 
+  /**
+   * Multi-vendor split: when a checkout spans products from N shops, a single
+   * parent order carries the customer-facing aggregates and N child orders (one
+   * per shop) carry per-vendor fulfilment. Null on stand-alone orders.
+   */
+  @Column(name = "parent_order_id")
+  private UUID parentOrderId;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 30)
   @Builder.Default

--- a/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
@@ -17,6 +17,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
+
 /**
  * CustomerOrder represents a confirmed purchase from a customer.
  *
@@ -36,6 +39,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Audited
 public class CustomerOrder {
 
   @Id
@@ -215,10 +219,12 @@ public class CustomerOrder {
 
   @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
+  @NotAudited
   private List<CustomerOrderItem> items = new ArrayList<>();
 
   @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
+  @NotAudited
   private List<OrderStatusHistory> statusHistory = new ArrayList<>();
 
   public enum OrderStatus {

--- a/src/main/java/com/xplaza/backend/order/domain/repository/CustomerOrderRepository.java
+++ b/src/main/java/com/xplaza/backend/order/domain/repository/CustomerOrderRepository.java
@@ -48,6 +48,8 @@ public interface CustomerOrderRepository extends JpaRepository<CustomerOrder, UU
 
   List<CustomerOrder> findByStatus(CustomerOrder.OrderStatus status);
 
+  List<CustomerOrder> findByParentOrderId(UUID parentOrderId);
+
   Page<CustomerOrder> findByStatus(CustomerOrder.OrderStatus status, Pageable pageable);
 
   long countByCouponCode(String couponCode);

--- a/src/main/java/com/xplaza/backend/order/service/CheckoutService.java
+++ b/src/main/java/com/xplaza/backend/order/service/CheckoutService.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.xplaza.backend.b2b.service.PriceListResolver;
 import com.xplaza.backend.cart.domain.entity.Cart;
 import com.xplaza.backend.cart.domain.entity.CartItem;
 import com.xplaza.backend.cart.domain.repository.CartRepository;
@@ -45,6 +46,7 @@ public class CheckoutService {
   private final CampaignService campaignService;
   private final TaxService taxService;
   private final CustomerAddressRepository customerAddressRepository;
+  private final PriceListResolver priceListResolver;
 
   /**
    * Start a new checkout session for a cart.
@@ -127,6 +129,11 @@ public class CheckoutService {
    */
   private void recalculateTax(CheckoutSession checkout) {
     if (checkout.getShippingAddressId() == null) {
+      return;
+    }
+    if (priceListResolver.isTaxExempt(checkout.getCustomerId())) {
+      checkout.setTaxAmount(BigDecimal.ZERO);
+      checkout.calculateGrandTotal();
       return;
     }
     CustomerAddress addr = customerAddressRepository.findById(checkout.getShippingAddressId()).orElse(null);

--- a/src/main/java/com/xplaza/backend/order/service/CheckoutService.java
+++ b/src/main/java/com/xplaza/backend/order/service/CheckoutService.java
@@ -19,11 +19,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.xplaza.backend.cart.domain.entity.Cart;
+import com.xplaza.backend.cart.domain.entity.CartItem;
 import com.xplaza.backend.cart.domain.repository.CartRepository;
+import com.xplaza.backend.customer.domain.entity.CustomerAddress;
+import com.xplaza.backend.customer.domain.repository.CustomerAddressRepository;
+import com.xplaza.backend.marketing.domain.entity.Campaign;
 import com.xplaza.backend.marketing.service.CampaignService;
 import com.xplaza.backend.order.domain.entity.CheckoutSession;
 import com.xplaza.backend.order.domain.entity.CustomerOrder;
 import com.xplaza.backend.order.domain.repository.CheckoutSessionRepository;
+import com.xplaza.backend.tax.service.TaxService;
 
 /**
  * Service for checkout operations.
@@ -38,6 +43,8 @@ public class CheckoutService {
   private final CartRepository cartRepository;
   private final CustomerOrderService customerOrderService;
   private final CampaignService campaignService;
+  private final TaxService taxService;
+  private final CustomerAddressRepository customerAddressRepository;
 
   /**
    * Start a new checkout session for a cart.
@@ -87,7 +94,8 @@ public class CheckoutService {
   }
 
   /**
-   * Set shipping address for checkout.
+   * Set shipping address for checkout. Re-runs the tax engine because the
+   * shipping destination determines which tax zone applies.
    */
   public CheckoutSession setShippingAddress(UUID checkoutId, Long addressId) {
     CheckoutSession checkout = getActiveCheckout(checkoutId);
@@ -95,11 +103,14 @@ public class CheckoutService {
     checkout.setShippingCompleted(true);
     checkout.setCurrentStep("PAYMENT");
     checkout.setStatus(CheckoutSession.CheckoutStatus.SHIPPING_SELECTED);
+    recalculateTax(checkout);
     return checkoutSessionRepository.save(checkout);
   }
 
   /**
-   * Set shipping method and cost.
+   * Set shipping method and cost. Tax usually depends on the pre-tax subtotal,
+   * not the shipping line, but free-shipping promotions are validated here so we
+   * recompute the grand total after.
    */
   public CheckoutSession setShippingMethod(UUID checkoutId, Long methodId, String methodName, BigDecimal cost) {
     CheckoutSession checkout = getActiveCheckout(checkoutId);
@@ -108,6 +119,27 @@ public class CheckoutService {
     checkout.setShippingCost(cost);
     checkout.calculateGrandTotal();
     return checkoutSessionRepository.save(checkout);
+  }
+
+  /**
+   * Resolve the shipping address and recompute the tax breakdown using
+   * {@link TaxService}. Called whenever the destination changes.
+   */
+  private void recalculateTax(CheckoutSession checkout) {
+    if (checkout.getShippingAddressId() == null) {
+      return;
+    }
+    CustomerAddress addr = customerAddressRepository.findById(checkout.getShippingAddressId()).orElse(null);
+    if (addr == null) {
+      return;
+    }
+    BigDecimal taxableBase = checkout.getSubtotal() == null ? BigDecimal.ZERO : checkout.getSubtotal();
+    if (checkout.getDiscountAmount() != null) {
+      taxableBase = taxableBase.subtract(checkout.getDiscountAmount()).max(BigDecimal.ZERO);
+    }
+    var breakdown = taxService.computeTax(taxableBase, addr.getCountryCode(), addr.getState());
+    checkout.setTaxAmount(breakdown.totalTax());
+    checkout.calculateGrandTotal();
   }
 
   /**
@@ -147,16 +179,16 @@ public class CheckoutService {
   }
 
   /**
-   * Apply coupon to checkout.
+   * Apply coupon to checkout. Builds a {@link Campaign.DiscountContext} from the
+   * cart so BOGO/FREE_SHIPPING/BUNDLE campaigns can compute correctly.
    */
   public CheckoutSession applyCoupon(UUID checkoutId, String couponCode) {
     CheckoutSession checkout = getActiveCheckout(checkoutId);
 
-    // Validate coupon and calculate discount
     long usageCount = customerOrderService.countOrdersByCouponCode(couponCode);
-    BigDecimal discountAmount = campaignService.validateCoupon(couponCode, checkout.getSubtotal(), (int) usageCount);
+    var ctx = buildDiscountContext(checkout);
+    BigDecimal discountAmount = campaignService.validateCoupon(couponCode, ctx, (int) usageCount);
 
-    // Get campaign ID
     Long campaignId = campaignService.getCampaignByCode(couponCode)
         .map(c -> c.getCampaignId())
         .orElseThrow(() -> new IllegalArgumentException("Campaign not found: " + couponCode));
@@ -165,8 +197,23 @@ public class CheckoutService {
     checkout.setCouponCode(couponCode);
     checkout.setCouponDiscountAmount(discountAmount);
     checkout.setDiscountAmount(checkout.getDiscountAmount().add(discountAmount));
-    checkout.calculateGrandTotal();
+    recalculateTax(checkout);
     return checkoutSessionRepository.save(checkout);
+  }
+
+  private Campaign.DiscountContext buildDiscountContext(CheckoutSession checkout) {
+    BigDecimal subtotal = checkout.getSubtotal() == null ? BigDecimal.ZERO : checkout.getSubtotal();
+    BigDecimal shipping = checkout.getShippingCost() == null ? BigDecimal.ZERO : checkout.getShippingCost();
+    var lines = cartRepository.findByIdWithItems(checkout.getCartId())
+        .map(c -> c.getActiveItems().stream()
+            .map(this::toDiscountLine)
+            .toList())
+        .orElse(java.util.List.of());
+    return new Campaign.DiscountContext(subtotal, shipping, lines);
+  }
+
+  private Campaign.DiscountLine toDiscountLine(CartItem item) {
+    return new Campaign.DiscountLine(item.getProductId(), item.getQuantity(), item.getUnitPrice());
   }
 
   /**
@@ -180,7 +227,7 @@ public class CheckoutService {
     checkout.setCouponId(null);
     checkout.setCouponCode(null);
     checkout.setCouponDiscountAmount(null);
-    checkout.calculateGrandTotal();
+    recalculateTax(checkout);
     return checkoutSessionRepository.save(checkout);
   }
 

--- a/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
+++ b/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
@@ -25,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.xplaza.backend.cart.domain.entity.Cart;
 import com.xplaza.backend.cart.domain.entity.CartItem;
 import com.xplaza.backend.cart.domain.repository.CartRepository;
+import com.xplaza.backend.common.events.DomainEventPublisher;
+import com.xplaza.backend.common.events.DomainEvents;
 import com.xplaza.backend.inventory.service.InventoryService;
 import com.xplaza.backend.notification.domain.entity.Notification;
 import com.xplaza.backend.notification.service.NotificationService;
@@ -51,6 +53,7 @@ public class CustomerOrderService {
   private final PaymentService paymentService;
   private final NotificationService notificationService;
   private final InventoryService inventoryService;
+  private final DomainEventPublisher domainEventPublisher;
 
   private static final DateTimeFormatter ORDER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
   private static final Random RANDOM = new Random();
@@ -134,7 +137,23 @@ public class CustomerOrderService {
 
     log.info("Created order {} from cart {}", savedOrder.getOrderNumber(), cart.getId());
 
-    // Send notification
+    // Publish OrderPlaced via the transactional outbox so loyalty points,
+    // co-purchase recommendations and email follow-ups all observe the same
+    // committed order. This used to be a TODO and as a result both the
+    // LoyaltyService and RecommendationService listeners were dead code.
+    try {
+      domainEventPublisher.publish(new DomainEvents.OrderPlaced(
+          UUID.randomUUID(),
+          Instant.now(),
+          savedOrder.getOrderId(),
+          savedOrder.getCustomerId(),
+          savedOrder.getShopId(),
+          savedOrder.getGrandTotal(),
+          savedOrder.getCurrency()));
+    } catch (Exception e) {
+      log.error("Failed to publish OrderPlaced for {}: {}", savedOrder.getOrderId(), e.toString());
+    }
+
     try {
       notificationService.createOrderNotification(
           savedOrder.getCustomerId(),

--- a/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
+++ b/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
@@ -57,6 +57,7 @@ public class CustomerOrderService {
 
   private static final DateTimeFormatter ORDER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
   private static final Random RANDOM = new Random();
+  private static final java.math.RoundingMode HALF_UP = java.math.RoundingMode.HALF_UP;
 
   /**
    * Create an order from a checkout session.
@@ -105,9 +106,7 @@ public class CustomerOrderService {
         .placedAt(Instant.now())
         .build();
 
-    // Copy cart items to order items
     for (CartItem cartItem : cart.getActiveItems()) {
-      // Reserve stock
       inventoryService.reserveStockAnyWarehouse(cartItem.getProductId(), cartItem.getVariantId(),
           cartItem.getQuantity(), order.getOrderId());
 
@@ -126,12 +125,16 @@ public class CustomerOrderService {
       order.addItem(orderItem);
     }
 
-    // Record initial status
     order.changeStatus(CustomerOrder.OrderStatus.PENDING, "Order created", "system");
 
     CustomerOrder savedOrder = orderRepository.save(order);
 
-    // Mark cart as converted
+    // Multi-vendor split: when the cart spans multiple shops the saved order
+    // becomes the *parent*; per-shop child orders are then minted with shared
+    // ids in `parent_order_id`. Each child carries a proportional slice of
+    // shipping / tax / discount so vendor payouts are clean.
+    splitForVendorsIfNeeded(savedOrder, cart);
+
     cart.markConverted();
     cartRepository.save(cart);
 
@@ -166,6 +169,88 @@ public class CustomerOrderService {
     }
 
     return savedOrder;
+  }
+
+  /**
+   * Walk the cart's lines, group them by shop, and if more than one shop is
+   * represented mint per-shop child orders linked to the parent via
+   * {@code parent_order_id}. Each child gets the full per-shop subtotal and a
+   * proportional slice of shipping, discount and tax.
+   */
+  private void splitForVendorsIfNeeded(CustomerOrder parent, Cart cart) {
+    var byShop = cart.getActiveItems().stream()
+        .collect(java.util.stream.Collectors.groupingBy(CartItem::getShopId));
+    if (byShop.size() < 2) {
+      return;
+    }
+    BigDecimal parentSubtotal = parent.getSubtotal();
+    if (parentSubtotal == null || parentSubtotal.signum() <= 0) {
+      return;
+    }
+    int childIndex = 0;
+    for (var entry : byShop.entrySet()) {
+      Long shopId = entry.getKey();
+      var lines = entry.getValue();
+      BigDecimal shopSubtotal = lines.stream()
+          .map(CartItem::getLineTotal)
+          .reduce(BigDecimal.ZERO, BigDecimal::add);
+      BigDecimal weight = shopSubtotal.divide(parentSubtotal, 6, HALF_UP);
+      BigDecimal shopShipping = nz(parent.getShippingCost()).multiply(weight).setScale(2, HALF_UP);
+      BigDecimal shopDiscount = nz(parent.getDiscountAmount()).multiply(weight).setScale(2, HALF_UP);
+      BigDecimal shopTax = nz(parent.getTaxAmount()).multiply(weight).setScale(2, HALF_UP);
+      BigDecimal shopTotal = shopSubtotal.add(shopShipping).add(shopTax).subtract(shopDiscount).max(BigDecimal.ZERO);
+
+      CustomerOrder child = CustomerOrder.builder()
+          .orderNumber(parent.getOrderNumber() + "-V" + (++childIndex))
+          .customerId(parent.getCustomerId())
+          .shopId(shopId)
+          .cartId(parent.getCartId())
+          .parentOrderId(parent.getOrderId())
+          .status(CustomerOrder.OrderStatus.PENDING)
+          .subtotal(shopSubtotal)
+          .discountAmount(shopDiscount)
+          .shippingCost(shopShipping)
+          .taxAmount(shopTax)
+          .grandTotal(shopTotal)
+          .currency(parent.getCurrency())
+          .shippingAddressId(parent.getShippingAddressId())
+          .billingAddressId(parent.getBillingAddressId())
+          .billingSameAsShipping(parent.getBillingSameAsShipping())
+          .placedAt(parent.getPlacedAt())
+          .paymentTypeId(parent.getPaymentTypeId())
+          .paymentMethod(parent.getPaymentMethod())
+          .build();
+      for (CartItem ci : lines) {
+        child.addItem(CustomerOrderItem.builder()
+            .order(child)
+            .productId(ci.getProductId())
+            .variantId(ci.getVariantId())
+            .shopId(ci.getShopId())
+            .productName(ci.getProductName() != null ? ci.getProductName() : "Product " + ci.getProductId())
+            .quantity(ci.getQuantity())
+            .unitPrice(ci.getUnitPrice())
+            .discountAmount(ci.getDiscountAmount())
+            .totalPrice(ci.getLineTotal())
+            .build());
+      }
+      child.changeStatus(CustomerOrder.OrderStatus.PENDING,
+          "Auto-split from parent " + parent.getOrderNumber(), "system");
+      orderRepository.save(child);
+    }
+    log.info("Split order {} into {} per-shop child orders", parent.getOrderNumber(), byShop.size());
+  }
+
+  private static BigDecimal nz(BigDecimal v) {
+    return v == null ? BigDecimal.ZERO : v;
+  }
+
+  /**
+   * Return per-shop child orders for a parent order id. Empty list when the order
+   * is stand-alone.
+   */
+  @Transactional(readOnly = true)
+  public List<CustomerOrder> getChildOrders(UUID parentOrderId) {
+    return orderRepository.findByParentOrderId(parentOrderId);
   }
 
   /**

--- a/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
+++ b/src/main/java/com/xplaza/backend/order/service/CustomerOrderService.java
@@ -172,6 +172,98 @@ public class CustomerOrderService {
   }
 
   /**
+   * Mint a renewal order for a subscription without going through the cart
+   * pipeline. The caller supplies the resolved line items (already priced by the
+   * subscription's snapshot), and we create a {@link CustomerOrder} in
+   * {@code PENDING} state, publish {@code OrderPlaced} and return it.
+   *
+   * <p>
+   * The order uses a synthetic order number suffixed with {@code -SUB<id>} so
+   * renewals are easy to spot in reports and so a reconciliation job can map them
+   * back to the originating subscription without touching metadata.
+   */
+  public CustomerOrder createSubscriptionOrder(Long customerId, String currency,
+      List<SubscriptionOrderLine> lines, Long subscriptionId) {
+    if (lines == null || lines.isEmpty()) {
+      throw new IllegalArgumentException("Subscription renewal requires at least one line item");
+    }
+    String baseOrderNumber = generateOrderNumber();
+    String orderNumber = baseOrderNumber + "-SUB" + subscriptionId;
+
+    BigDecimal subtotal = lines.stream()
+        .map(l -> l.unitPrice().multiply(BigDecimal.valueOf(l.quantity())))
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    // Pick the shop of the first line as the "primary" shop so the single-shop
+    // summary renders sensibly. Multi-vendor split is intentionally NOT run
+    // for renewals in this release: the renewal snapshot carries only the
+    // item list + subscription price, not the shipping/tax allocation that
+    // the split logic needs. v1.2 will revisit this once
+    // `OrderService.createSubscriptionOrder(...)` can consult the tax/shipping
+    // engine at renewal time.
+    Long primaryShopId = lines.get(0).shopId();
+
+    CustomerOrder order = CustomerOrder.builder()
+        .orderNumber(orderNumber)
+        .customerId(customerId)
+        .shopId(primaryShopId)
+        .status(CustomerOrder.OrderStatus.PENDING)
+        .subtotal(subtotal)
+        .discountAmount(BigDecimal.ZERO)
+        .shippingCost(BigDecimal.ZERO)
+        .taxAmount(BigDecimal.ZERO)
+        .grandTotal(subtotal)
+        .currency(currency == null ? "USD" : currency)
+        .paymentMethod("SUBSCRIPTION")
+        .placedAt(Instant.now())
+        .build();
+
+    for (SubscriptionOrderLine line : lines) {
+      CustomerOrderItem orderItem = CustomerOrderItem.builder()
+          .order(order)
+          .productId(line.productId())
+          .shopId(line.shopId())
+          .productName(line.productName() != null ? line.productName() : "Product " + line.productId())
+          .quantity(line.quantity())
+          .unitPrice(line.unitPrice())
+          .discountAmount(BigDecimal.ZERO)
+          .totalPrice(line.unitPrice().multiply(BigDecimal.valueOf(line.quantity())))
+          .build();
+      order.addItem(orderItem);
+    }
+
+    order.changeStatus(CustomerOrder.OrderStatus.PENDING, "Subscription renewal", "system");
+    CustomerOrder saved = orderRepository.save(order);
+
+    try {
+      domainEventPublisher.publish(new DomainEvents.OrderPlaced(
+          UUID.randomUUID(),
+          Instant.now(),
+          saved.getOrderId(),
+          saved.getCustomerId(),
+          saved.getShopId(),
+          saved.getGrandTotal(),
+          saved.getCurrency()));
+    } catch (Exception e) {
+      log.error("Failed to publish OrderPlaced for subscription renewal {}: {}", saved.getOrderId(), e.toString());
+    }
+    return saved;
+  }
+
+  /**
+   * Wire-format line item for {@link #createSubscriptionOrder}. Keeps this
+   * service insulated from the subscription module's own entity types.
+   */
+  public record SubscriptionOrderLine(
+      Long productId,
+      Long shopId,
+      String productName,
+      int quantity,
+      BigDecimal unitPrice
+  ) {
+  }
+
+  /**
    * Walk the cart's lines, group them by shop, and if more than one shop is
    * represented mint per-shop child orders linked to the parent via
    * {@code parent_order_id}. Each child gets the full per-shop subtotal and a

--- a/src/main/java/com/xplaza/backend/payment/domain/entity/PaymentTransaction.java
+++ b/src/main/java/com/xplaza/backend/payment/domain/entity/PaymentTransaction.java
@@ -13,6 +13,8 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.envers.Audited;
+
 /**
  * Payment Transaction records all payment attempts and their outcomes.
  * 
@@ -27,6 +29,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Audited
 public class PaymentTransaction {
 
   @Id

--- a/src/main/java/com/xplaza/backend/payment/domain/entity/Refund.java
+++ b/src/main/java/com/xplaza/backend/payment/domain/entity/Refund.java
@@ -15,6 +15,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
+
 /**
  * Refund request for an order.
  * 
@@ -27,6 +30,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Audited
 public class Refund {
 
   @Id
@@ -115,6 +119,7 @@ public class Refund {
 
   @OneToMany(mappedBy = "refund", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
+  @NotAudited
   private List<RefundItem> items = new ArrayList<>();
 
   public enum RefundStatus {

--- a/src/main/java/com/xplaza/backend/payment/service/StripePaymentGateway.java
+++ b/src/main/java/com/xplaza/backend/payment/service/StripePaymentGateway.java
@@ -9,6 +9,9 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+
 import org.springframework.stereotype.Service;
 
 import com.stripe.exception.StripeException;
@@ -20,6 +23,8 @@ import com.stripe.param.PaymentIntentCreateParams;
 public class StripePaymentGateway implements PaymentGateway {
 
   @Override
+  @CircuitBreaker(name = "stripe")
+  @Retry(name = "stripe")
   public PaymentIntent createPaymentIntent(BigDecimal amount, String currency, String description,
       Map<String, String> metadata) throws StripeException {
     Map<String, String> meta = metadata == null ? new HashMap<>() : new HashMap<>(metadata);
@@ -42,6 +47,8 @@ public class StripePaymentGateway implements PaymentGateway {
   }
 
   @Override
+  @CircuitBreaker(name = "stripe")
+  @Retry(name = "stripe")
   public PaymentIntent confirmPaymentIntent(String paymentIntentId) throws StripeException {
     PaymentIntent paymentIntent = PaymentIntent.retrieve(paymentIntentId);
     Map<String, Object> params = new HashMap<>();

--- a/src/main/java/com/xplaza/backend/payment/service/StripePaymentGateway.java
+++ b/src/main/java/com/xplaza/backend/payment/service/StripePaymentGateway.java
@@ -6,11 +6,19 @@
 package com.xplaza.backend.payment.service;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.UUID;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 
@@ -20,7 +28,17 @@ import com.stripe.net.RequestOptions;
 import com.stripe.param.PaymentIntentCreateParams;
 
 @Service
+@Slf4j
 public class StripePaymentGateway implements PaymentGateway {
+
+  /**
+   * Conventional metadata keys callers can populate so the fallback idempotency
+   * key remains stable across retries while still being unique per business
+   * operation. Listed in priority order — the first non-blank value wins.
+   */
+  private static final String[] IDENTITY_META_KEYS = {
+      "orderId", "checkoutSessionId", "cartId", "customerId", "paymentIntentRef"
+  };
 
   @Override
   @CircuitBreaker(name = "stripe")
@@ -38,12 +56,69 @@ public class StripePaymentGateway implements PaymentGateway {
                 .setEnabled(true)
                 .build())
         .build();
-    // Stripe-side idempotency: prefer caller-supplied key, fall back to a stable
-    // hash.
-    String idempotencyKey = meta.getOrDefault("idempotencyKey",
-        "create-pi-" + (description == null ? "" : description.hashCode()) + "-" + amount + currency);
+    String idempotencyKey = resolveIdempotencyKey(amount, currency, description, meta);
     var options = RequestOptions.builder().setIdempotencyKey(idempotencyKey).build();
     return PaymentIntent.create(params, options);
+  }
+
+  /**
+   * Builds a Stripe idempotency key with enough entropy to never collide across
+   * unrelated payments while still de-duplicating intentional retries.
+   *
+   * <p>
+   * Resolution order:
+   * <ol>
+   * <li>Caller-supplied {@code metadata.idempotencyKey} — wins outright.</li>
+   * <li>SHA-256 over {@code amount}, {@code currency}, {@code description} and
+   * the entire (sorted) metadata map. Stable across retries of the same logical
+   * operation, distinct as soon as <em>any</em> identifying field differs.</li>
+   * <li>If the metadata map is empty <em>and</em> {@code description} is null
+   * (i.e. nothing differentiates this call), we fall through to a per-call UUID
+   * and log a warning. Without identifying context the only safe default is to
+   * forfeit Stripe-side retry de-duplication rather than silently collide with
+   * every other amount-equal payment.</li>
+   * </ol>
+   */
+  private String resolveIdempotencyKey(BigDecimal amount, String currency, String description,
+      Map<String, String> meta) {
+    String supplied = meta.get("idempotencyKey");
+    if (supplied != null && !supplied.isBlank()) {
+      return supplied;
+    }
+    boolean hasIdentity = description != null && !description.isBlank();
+    if (!hasIdentity) {
+      for (String key : IDENTITY_META_KEYS) {
+        String v = meta.get(key);
+        if (v != null && !v.isBlank()) {
+          hasIdentity = true;
+          break;
+        }
+      }
+    }
+    if (!hasIdentity && meta.isEmpty()) {
+      String key = "create-pi-nocontext-" + UUID.randomUUID();
+      log.warn("Stripe createPaymentIntent called without identifying context "
+          + "(no metadata, no description); falling back to a per-call UUID idempotency key '{}'. "
+          + "Network retries will create duplicate intents — supply metadata.idempotencyKey or an orderId.",
+          key);
+      return key;
+    }
+    String fingerprint = sha256Hex(
+        amount + "|"
+            + currency + "|"
+            + Objects.toString(description, "") + "|"
+            + new TreeMap<>(meta));
+    return "create-pi-" + fingerprint;
+  }
+
+  private static String sha256Hex(String input) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(md.digest(input.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      // SHA-256 is mandated by every JRE; this is unreachable in practice.
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
   }
 
   @Override

--- a/src/main/java/com/xplaza/backend/recommendation/domain/repository/ProductCoPurchaseRepository.java
+++ b/src/main/java/com/xplaza/backend/recommendation/domain/repository/ProductCoPurchaseRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,15 @@ public interface ProductCoPurchaseRepository extends JpaRepository<ProductCoPurc
 
   @Query("SELECT cp FROM ProductCoPurchase cp WHERE cp.productId = :productId ORDER BY cp.coPurchaseCount DESC")
   List<ProductCoPurchase> findTopByProductId(@Param("productId") Long productId, Pageable page);
+
+  /**
+   * Atomic upsert/increment for the (product, coProduct) pair. Postgres
+   * {@code ON CONFLICT} keeps the worker race-free under bursty traffic.
+   */
+  @Modifying
+  @Query(value = "INSERT INTO product_co_purchases(product_id, co_product_id, co_purchase_count) "
+      + "VALUES (:productId, :coProductId, 1) "
+      + "ON CONFLICT (product_id, co_product_id) "
+      + "DO UPDATE SET co_purchase_count = product_co_purchases.co_purchase_count + 1", nativeQuery = true)
+  void incrementPair(@Param("productId") Long productId, @Param("coProductId") Long coProductId);
 }

--- a/src/main/java/com/xplaza/backend/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/xplaza/backend/recommendation/service/RecommendationService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.xplaza.backend.catalog.domain.entity.Product;
 import com.xplaza.backend.catalog.domain.repository.ProductRepository;
 import com.xplaza.backend.common.events.DomainEvents;
+import com.xplaza.backend.order.domain.repository.CustomerOrderRepository;
 import com.xplaza.backend.recommendation.domain.entity.ProductCoPurchase;
 import com.xplaza.backend.recommendation.domain.entity.RecentlyViewedProduct;
 import com.xplaza.backend.recommendation.domain.repository.ProductCoPurchaseRepository;
@@ -39,6 +40,7 @@ public class RecommendationService {
   private final RecentlyViewedProductRepository recentlyViewedRepo;
   private final ProductCoPurchaseRepository coPurchaseRepo;
   private final ProductRepository productRepo;
+  private final CustomerOrderRepository orderRepo;
 
   /**
    * Records a product view for a customer. Idempotent because the row id is
@@ -92,11 +94,38 @@ public class RecommendationService {
         .toList();
   }
 
+  /**
+   * Walk the just-placed order's line items and increment the symmetric
+   * co-purchase counter for each unordered (a, b) pair. Runs asynchronously so it
+   * never blocks the checkout commit.
+   */
   @Async
   @EventListener
+  @Transactional
   public void onOrderPlaced(DomainEvents.OrderPlaced event) {
-    // TODO: increment co-purchase counters from the order line items. Left as a
-    // hook so a downstream worker can populate the recommendation table.
-    log.debug("Recording co-purchases for order {}", event.orderId());
+    try {
+      var order = orderRepo.findByIdWithItems(event.orderId()).orElse(null);
+      if (order == null || order.getItems() == null || order.getItems().size() < 2) {
+        return;
+      }
+      var productIds = order.getItems().stream()
+          .map(i -> i.getProductId())
+          .filter(java.util.Objects::nonNull)
+          .distinct()
+          .sorted()
+          .toList();
+      for (int i = 0; i < productIds.size(); i++) {
+        for (int j = i + 1; j < productIds.size(); j++) {
+          Long a = productIds.get(i);
+          Long b = productIds.get(j);
+          coPurchaseRepo.incrementPair(a, b);
+          coPurchaseRepo.incrementPair(b, a);
+        }
+      }
+      log.debug("Recorded {} co-purchase pairs for order {}",
+          productIds.size() * (productIds.size() - 1), event.orderId());
+    } catch (Exception e) {
+      log.warn("Failed to record co-purchases for order {}: {}", event.orderId(), e.toString());
+    }
   }
 }

--- a/src/main/java/com/xplaza/backend/search/controller/SearchController.java
+++ b/src/main/java/com/xplaza/backend/search/controller/SearchController.java
@@ -5,15 +5,14 @@
 
 package com.xplaza.backend.search.controller;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import com.xplaza.backend.common.util.ApiResponse;
 import com.xplaza.backend.search.document.ProductDocument;
@@ -39,14 +38,63 @@ public class SearchController {
   public ResponseEntity<ApiResponse<List<ProductDocument>>> products(
       @RequestParam(name = "q", required = false) String q,
       @RequestParam(name = "page", defaultValue = "0") int page,
-      @RequestParam(name = "size", defaultValue = "20") int size) {
+      @RequestParam(name = "size", defaultValue = "20") int size,
+      @RequestParam Map<String, String> all) {
     var service = searchProvider.getIfAvailable();
     if (service == null) {
       return ResponseEntity.ok(ApiResponse.ok(List.of()));
     }
-    var hits = service.search(q, Map.of(), page, size);
+    var filters = stripPagingParams(all);
+    var hits = service.search(q, filters, page, size);
     var docs = hits.stream().map(h -> h.getContent()).toList();
     return ResponseEntity.ok(ApiResponse.ok(docs));
+  }
+
+  /**
+   * Faceted search returning hits + aggregations (brand / category / price
+   * histogram). Storefronts use this to render filter sidebars.
+   */
+  @GetMapping("/products/faceted")
+  public ResponseEntity<ApiResponse<Map<String, Object>>> faceted(
+      @RequestParam(name = "q", required = false) String q,
+      @RequestParam(name = "page", defaultValue = "0") int page,
+      @RequestParam(name = "size", defaultValue = "20") int size,
+      @RequestParam Map<String, String> all) {
+    var service = searchProvider.getIfAvailable();
+    if (service == null) {
+      return ResponseEntity.ok(ApiResponse.ok(Map.of("hits", List.of(), "facets", Map.of())));
+    }
+    var filters = stripPagingParams(all);
+    var hits = service.search(q, filters, page, size, true);
+    Map<String, Object> body = new HashMap<>();
+    body.put("hits", hits.stream().map(h -> h.getContent()).toList());
+    body.put("total", hits.getTotalHits());
+    body.put("aggregations", hits.getAggregations());
+    return ResponseEntity.ok(ApiResponse.ok(body));
+  }
+
+  /**
+   * Admin-only bulk reindex. Walks the products table in batches and pushes every
+   * row to Elasticsearch. Returns the number of documents indexed.
+   */
+  @PostMapping("/reindex")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<ApiResponse<Map<String, Object>>> reindex(
+      @RequestParam(name = "batchSize", defaultValue = "500") int batchSize) {
+    var service = searchProvider.getIfAvailable();
+    if (service == null) {
+      return ResponseEntity.status(503).body(ApiResponse.ok(Map.of("status", "search-disabled")));
+    }
+    int total = service.reindexAll(batchSize);
+    return ResponseEntity.ok(ApiResponse.ok(Map.of("status", "ok", "indexed", total)));
+  }
+
+  private static Map<String, String> stripPagingParams(Map<String, String> all) {
+    Map<String, String> filters = new HashMap<>(all);
+    filters.remove("q");
+    filters.remove("page");
+    filters.remove("size");
+    return filters;
   }
 
   @GetMapping("/autocomplete")

--- a/src/main/java/com/xplaza/backend/search/service/ProductSearchService.java
+++ b/src/main/java/com/xplaza/backend/search/service/ProductSearchService.java
@@ -91,11 +91,14 @@ public class ProductSearchService {
             .fuzziness("AUTO"))._toQuery());
       }
       if (filters != null) {
-        applyTermFilter(b, filters, "shopId", "shopId");
-        applyTermFilter(b, filters, "brand", "brand");
-        applyTermFilter(b, filters, "category", "category");
-        applyTermFilter(b, filters, "currency", "currency");
-        applyTermFilter(b, filters, "published", "published");
+        // Numeric and boolean filters must be parsed to their typed FieldValue
+        // otherwise Elasticsearch's term query compiles as a string comparison
+        // against an indexed long/bool field and silently returns zero hits.
+        applyLongTermFilter(b, filters, "shopId", "shopId");
+        applyStringTermFilter(b, filters, "brand", "brand");
+        applyStringTermFilter(b, filters, "category", "category");
+        applyStringTermFilter(b, filters, "currency", "currency");
+        applyBooleanTermFilter(b, filters, "published", "published");
         applyPriceRange(b, filters);
       }
       return b;
@@ -115,10 +118,43 @@ public class ProductSearchService {
     return operations.search(query, ProductDocument.class);
   }
 
-  private static void applyTermFilter(BoolQuery.Builder b, Map<String, String> filters, String key, String field) {
+  private static void applyStringTermFilter(BoolQuery.Builder b, Map<String, String> filters,
+      String key, String field) {
     var v = filters.get(key);
     if (v != null && !v.isBlank()) {
       b.filter(TermQuery.of(t -> t.field(field).value(v))._toQuery());
+    }
+  }
+
+  private static void applyLongTermFilter(BoolQuery.Builder b, Map<String, String> filters,
+      String key, String field) {
+    var v = filters.get(key);
+    if (v == null || v.isBlank()) {
+      return;
+    }
+    try {
+      long parsed = Long.parseLong(v.trim());
+      b.filter(TermQuery.of(t -> t.field(field).value(parsed))._toQuery());
+    } catch (NumberFormatException e) {
+      log.debug("Skipping non-numeric filter for '{}' = '{}'", key, v);
+    }
+  }
+
+  private static void applyBooleanTermFilter(BoolQuery.Builder b, Map<String, String> filters,
+      String key, String field) {
+    var v = filters.get(key);
+    if (v == null || v.isBlank()) {
+      return;
+    }
+    String trimmed = v.trim();
+    // Only accept the canonical spellings so we don't silently treat "yes"
+    // as false. Anything else is ignored (a filter-not-applied is safer than
+    // a wrong filter applied).
+    if (trimmed.equalsIgnoreCase("true") || trimmed.equalsIgnoreCase("false")) {
+      boolean parsed = Boolean.parseBoolean(trimmed);
+      b.filter(TermQuery.of(t -> t.field(field).value(parsed))._toQuery());
+    } else {
+      log.debug("Skipping non-boolean filter for '{}' = '{}'", key, v);
     }
   }
 

--- a/src/main/java/com/xplaza/backend/search/service/ProductSearchService.java
+++ b/src/main/java/com/xplaza/backend/search/service/ProductSearchService.java
@@ -8,8 +8,14 @@ package com.xplaza.backend.search.service;
 import java.time.Instant;
 import java.util.*;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +60,8 @@ public class ProductSearchService {
 
   /** Reindex a single product. Called from event listener. */
   @Async
+  @CircuitBreaker(name = "elasticsearch")
+  @Retry(name = "elasticsearch")
   public void reindex(Long productId) {
     productRepository.findById(productId).ifPresent(p -> documentRepository.save(toDocument(p)));
   }
@@ -63,18 +71,112 @@ public class ProductSearchService {
   }
 
   public SearchHits<ProductDocument> search(String q, Map<String, String> filters, int page, int size) {
+    return search(q, filters, page, size, false);
+  }
+
+  /**
+   * Full-text search + structured filters + (optional) facet aggregations.
+   * Filters honoured: shopId, brand, category, minPrice, maxPrice, published.
+   * When {@code withFacets} is true the response includes term aggregations for
+   * brand and category and a histogram for price.
+   */
+  public SearchHits<ProductDocument> search(String q, Map<String, String> filters, int page, int size,
+      boolean withFacets) {
+    var bool = BoolQuery.of(b -> {
+      if (q != null && !q.isBlank()) {
+        b.must(MultiMatchQuery.of(m -> m
+            .query(q)
+            .fields("name^3", "nameSuggest^2", "description", "brand", "category", "tags")
+            .operator(Operator.And)
+            .fuzziness("AUTO"))._toQuery());
+      }
+      if (filters != null) {
+        applyTermFilter(b, filters, "shopId", "shopId");
+        applyTermFilter(b, filters, "brand", "brand");
+        applyTermFilter(b, filters, "category", "category");
+        applyTermFilter(b, filters, "currency", "currency");
+        applyTermFilter(b, filters, "published", "published");
+        applyPriceRange(b, filters);
+      }
+      return b;
+    });
     var nativeQueryBuilder = NativeQuery.builder()
+        .withQuery(bool._toQuery())
         .withPageable(PageRequest.of(page, size));
-    if (q != null && !q.isBlank()) {
-      var mm = MultiMatchQuery.of(m -> m
-          .query(q)
-          .fields("name^3", "nameSuggest^2", "description", "brand", "category", "tags")
-          .operator(Operator.And)
-          .fuzziness("AUTO"))._toQuery();
-      nativeQueryBuilder.withQuery(mm);
+    if (withFacets) {
+      nativeQueryBuilder.withAggregation("brand",
+          Aggregation.of(a -> a.terms(t -> t.field("brand").size(50))));
+      nativeQueryBuilder.withAggregation("category",
+          Aggregation.of(a -> a.terms(t -> t.field("category").size(50))));
+      nativeQueryBuilder.withAggregation("price",
+          Aggregation.of(a -> a.histogram(h -> h.field("price").interval(50.0))));
     }
     Query query = nativeQueryBuilder.build();
     return operations.search(query, ProductDocument.class);
+  }
+
+  private static void applyTermFilter(BoolQuery.Builder b, Map<String, String> filters, String key, String field) {
+    var v = filters.get(key);
+    if (v != null && !v.isBlank()) {
+      b.filter(TermQuery.of(t -> t.field(field).value(v))._toQuery());
+    }
+  }
+
+  private static void applyPriceRange(BoolQuery.Builder b, Map<String, String> filters) {
+    var min = parseDouble(filters.get("minPrice"));
+    var max = parseDouble(filters.get("maxPrice"));
+    if (min == null && max == null) {
+      return;
+    }
+    b.filter(RangeQuery.of(r -> {
+      var nb = r.number(n -> {
+        var nbb = n.field("price");
+        if (min != null) {
+          nbb.gte(min);
+        }
+        if (max != null) {
+          nbb.lte(max);
+        }
+        return nbb;
+      });
+      return nb;
+    })._toQuery());
+  }
+
+  private static Double parseDouble(String s) {
+    if (s == null || s.isBlank()) {
+      return null;
+    }
+    try {
+      return Double.parseDouble(s);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Walk the entire products table in batches and rebuild the search index.
+   * Intended to be triggered manually (admin endpoint) after schema changes or as
+   * a recovery step when a partial outage left the index stale.
+   */
+  public int reindexAll(int batchSize) {
+    int total = 0;
+    int page = 0;
+    while (true) {
+      var slice = productRepository.findAll(PageRequest.of(page, batchSize));
+      if (slice.isEmpty()) {
+        break;
+      }
+      var docs = slice.stream().map(this::toDocument).toList();
+      documentRepository.saveAll(docs);
+      total += docs.size();
+      if (!slice.hasNext()) {
+        break;
+      }
+      page++;
+    }
+    log.info("Bulk reindex completed: {} products", total);
+    return total;
   }
 
   public List<String> autocomplete(String prefix, int limit) {

--- a/src/main/java/com/xplaza/backend/shop/domain/entity/Shop.java
+++ b/src/main/java/com/xplaza/backend/shop/domain/entity/Shop.java
@@ -5,10 +5,21 @@
 
 package com.xplaza.backend.shop.domain.entity;
 
+import java.math.BigDecimal;
+import java.time.Instant;
+
 import jakarta.persistence.*;
 
 import lombok.*;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+/**
+ * Marketplace shop. v1.1.0 adds {@code commissionRate} (per-shop override of
+ * the marketplace default), {@code payoutAccount} (Stripe account or bank
+ * reference) and soft-delete bookkeeping via {@code deleted_at}.
+ */
 @Table(name = "shops")
 @Entity
 @Getter
@@ -16,6 +27,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE shops SET deleted_at = CURRENT_TIMESTAMP WHERE shop_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Shop {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,4 +44,20 @@ public class Shop {
   private Long locationId;
 
   private String shopOwner;
+
+  /**
+   * Per-shop commission override. When null the marketplace default
+   * ({@code marketplace.default-commission-rate}) is used.
+   */
+  @Column(name = "commission_rate", precision = 5, scale = 4)
+  private BigDecimal commissionRate;
+
+  @Column(name = "payout_account", length = 255)
+  private String payoutAccount;
+
+  @Column(name = "payout_currency", length = 3)
+  private String payoutCurrency;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 }

--- a/src/main/java/com/xplaza/backend/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/xplaza/backend/subscription/controller/SubscriptionController.java
@@ -22,7 +22,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import com.xplaza.backend.b2b.service.PriceListResolver;
+import com.xplaza.backend.catalog.domain.entity.Product;
+import com.xplaza.backend.catalog.domain.repository.ProductRepository;
 import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.promotion.service.ProductDiscountService;
 import com.xplaza.backend.subscription.domain.entity.Subscription;
 import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
 import com.xplaza.backend.subscription.service.SubscriptionService;
@@ -34,18 +38,37 @@ import com.xplaza.backend.subscription.service.SubscriptionService;
 public class SubscriptionController {
 
   private final SubscriptionService subscriptionService;
+  private final ProductRepository productRepository;
+  private final ProductDiscountService productDiscountService;
+  private final PriceListResolver priceListResolver;
 
   @Operation(summary = "Create a subscription")
   @PostMapping
   @PreAuthorize("hasRole('CUSTOMER')")
   public ResponseEntity<Subscription> create(@AuthenticationPrincipal Customer principal,
       @RequestBody @Valid CreateSubscriptionRequest request) {
+    // Resolve the unit price server-side from catalog + active product discounts
+    // + any B2B contract pricing the customer is entitled to. Any client-supplied
+    // price is intentionally ignored: otherwise a malicious client could
+    // subscribe for $0.01 and happily pull renewal invoices at that price
+    // forever.
     var items = request.items().stream()
-        .map(it -> SubscriptionItem.builder()
-            .productId(it.productId())
-            .quantity(it.quantity())
-            .unitPrice(it.unitPrice())
-            .build())
+        .map(it -> {
+          Product product = productRepository.findById(it.productId())
+              .orElseThrow(() -> new IllegalArgumentException("Unknown product: " + it.productId()));
+          BigDecimal resolved = productDiscountService.calculateDiscountedPrice(product);
+          resolved = priceListResolver.resolveUnitPrice(
+              principal.getCustomerId(),
+              it.productId(),
+              it.quantity(),
+              request.currency(),
+              resolved);
+          return SubscriptionItem.builder()
+              .productId(it.productId())
+              .quantity(it.quantity())
+              .unitPrice(resolved)
+              .build();
+        })
         .toList();
     var sub = subscriptionService.create(principal.getCustomerId(), request.intervalUnit(),
         request.intervalCount(), request.currency(), items);
@@ -102,10 +125,14 @@ public class SubscriptionController {
   ) {
   }
 
+  /**
+   * Client item payload. Note: {@code unitPrice} is intentionally absent — price
+   * is resolved server-side in {@link #create} against the catalog, active
+   * product discounts and any B2B contract the customer is entitled to.
+   */
   public record Item(
       @NotNull Long productId,
-      @NotNull @Positive Integer quantity,
-      @NotNull BigDecimal unitPrice
+      @NotNull @Positive Integer quantity
   ) {
   }
 }

--- a/src/main/java/com/xplaza/backend/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/xplaza/backend/subscription/controller/SubscriptionController.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.controller;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.subscription.domain.entity.Subscription;
+import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
+import com.xplaza.backend.subscription.service.SubscriptionService;
+
+@RestController
+@RequestMapping("/api/v1/customer/subscriptions")
+@RequiredArgsConstructor
+@Tag(name = "Subscriptions", description = "Customer subscription management")
+public class SubscriptionController {
+
+  private final SubscriptionService subscriptionService;
+
+  @Operation(summary = "Create a subscription")
+  @PostMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Subscription> create(@AuthenticationPrincipal Customer principal,
+      @RequestBody @Valid CreateSubscriptionRequest request) {
+    var items = request.items().stream()
+        .map(it -> SubscriptionItem.builder()
+            .productId(it.productId())
+            .quantity(it.quantity())
+            .unitPrice(it.unitPrice())
+            .build())
+        .toList();
+    var sub = subscriptionService.create(principal.getCustomerId(), request.intervalUnit(),
+        request.intervalCount(), request.currency(), items);
+    return ResponseEntity.ok(sub);
+  }
+
+  @Operation(summary = "List my subscriptions")
+  @GetMapping
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<List<Subscription>> list(@AuthenticationPrincipal Customer principal) {
+    return ResponseEntity.ok(subscriptionService.listForCustomer(principal.getCustomerId()));
+  }
+
+  @Operation(summary = "Pause a subscription")
+  @PostMapping("/{id}/pause")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Subscription> pause(@AuthenticationPrincipal Customer principal,
+      @PathVariable Long id) {
+    requireOwnership(principal, id);
+    return ResponseEntity.ok(subscriptionService.pause(id));
+  }
+
+  @Operation(summary = "Resume a subscription")
+  @PostMapping("/{id}/resume")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Subscription> resume(@AuthenticationPrincipal Customer principal,
+      @PathVariable Long id) {
+    requireOwnership(principal, id);
+    return ResponseEntity.ok(subscriptionService.resume(id));
+  }
+
+  @Operation(summary = "Cancel a subscription")
+  @PostMapping("/{id}/cancel")
+  @PreAuthorize("hasRole('CUSTOMER')")
+  public ResponseEntity<Subscription> cancel(@AuthenticationPrincipal Customer principal,
+      @PathVariable Long id) {
+    requireOwnership(principal, id);
+    return ResponseEntity.ok(subscriptionService.cancel(id));
+  }
+
+  private void requireOwnership(Customer principal, Long subscriptionId) {
+    var s = subscriptionService.get(subscriptionId);
+    if (!principal.getCustomerId().equals(s.getCustomerId())) {
+      throw new org.springframework.security.access.AccessDeniedException(
+          "Subscription does not belong to current customer");
+    }
+  }
+
+  public record CreateSubscriptionRequest(
+      @NotNull Subscription.IntervalUnit intervalUnit,
+      @NotNull @Positive Integer intervalCount,
+      @NotNull String currency,
+      @NotEmpty List<@Valid Item> items
+  ) {
+  }
+
+  public record Item(
+      @NotNull Long productId,
+      @NotNull @Positive Integer quantity,
+      @NotNull BigDecimal unitPrice
+  ) {
+  }
+}

--- a/src/main/java/com/xplaza/backend/subscription/domain/entity/Subscription.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/entity/Subscription.java
@@ -78,9 +78,24 @@ public class Subscription {
   @Builder.Default
   private Instant updatedAt = Instant.now();
 
-  @OneToMany(mappedBy = "subscriptionId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+  // Bidirectional association: SubscriptionItem.subscription is the owning
+  // side. A unidirectional @JoinColumn here would make Hibernate INSERT child
+  // rows with a NULL FK and then UPDATE, which fails the NOT NULL constraint
+  // on `subscription_id`. The `addItem` helper keeps both sides in sync so
+  // callers can just mutate `items` and let CascadeType.ALL persist them.
+  @OneToMany(mappedBy = "subscription", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @Builder.Default
   private List<SubscriptionItem> items = new ArrayList<>();
+
+  /**
+   * Attach a child item to this subscription while keeping the bidirectional
+   * back-reference consistent (required for the owning-side INSERT to carry a
+   * non-null {@code subscription_id}).
+   */
+  public void addItem(SubscriptionItem item) {
+    item.setSubscription(this);
+    items.add(item);
+  }
 
   @PreUpdate
   protected void onUpdate() {

--- a/src/main/java/com/xplaza/backend/subscription/domain/entity/Subscription.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/entity/Subscription.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.domain.entity;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+/**
+ * Recurring subscription. Tracks the renewal schedule and lifecycle so the
+ * {@code SubscriptionRenewalScheduler} can mint a new order on each cycle.
+ */
+@Entity
+@Table(name = "subscriptions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Subscription {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "customer_id", nullable = false)
+  private Long customerId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  @Builder.Default
+  private SubscriptionStatus status = SubscriptionStatus.ACTIVE;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "interval_unit", nullable = false, length = 20)
+  private IntervalUnit intervalUnit;
+
+  @Column(name = "interval_count", nullable = false)
+  @Builder.Default
+  private Integer intervalCount = 1;
+
+  @Column(name = "currency", nullable = false, length = 3)
+  @Builder.Default
+  private String currency = "USD";
+
+  @Column(name = "total_amount", precision = 14, scale = 2)
+  private BigDecimal totalAmount;
+
+  @Column(name = "next_renewal_at")
+  private Instant nextRenewalAt;
+
+  @Column(name = "cancelled_at")
+  private Instant cancelledAt;
+
+  @Column(name = "gateway_customer_id", length = 100)
+  private String gatewayCustomerId;
+
+  @Column(name = "retry_count", nullable = false)
+  @Builder.Default
+  private Integer retryCount = 0;
+
+  @Column(name = "last_error", length = 500)
+  private String lastError;
+
+  @Column(name = "created_at", nullable = false)
+  @Builder.Default
+  private Instant createdAt = Instant.now();
+
+  @Column(name = "updated_at", nullable = false)
+  @Builder.Default
+  private Instant updatedAt = Instant.now();
+
+  @OneToMany(mappedBy = "subscriptionId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+  @Builder.Default
+  private List<SubscriptionItem> items = new ArrayList<>();
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
+
+  public enum SubscriptionStatus {
+    ACTIVE,
+    PAUSED,
+    CANCELLED,
+    FAILED
+  }
+
+  public enum IntervalUnit {
+    DAY,
+    WEEK,
+    MONTH,
+    YEAR
+  }
+}

--- a/src/main/java/com/xplaza/backend/subscription/domain/entity/SubscriptionItem.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/entity/SubscriptionItem.java
@@ -11,6 +11,8 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 @Table(name = "subscription_items")
 @Getter
@@ -24,7 +26,23 @@ public class SubscriptionItem {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "subscription_id", nullable = false)
+  // Bidirectional ManyToOne is the owning side of the FK so the INSERT statement
+  // already carries the subscription_id — an earlier unidirectional @JoinColumn
+  // on the parent would INSERT NULL and then UPDATE, which fails the NOT NULL
+  // check on `subscription_id`. Lazy + optional=false lets Hibernate avoid
+  // dereferencing the parent when rendering the FK.
+  // @JsonIgnore prevents the serializer from walking back up into the parent
+  // Subscription and blowing the max depth limit: Subscription.items →
+  // SubscriptionItem.subscription → Subscription.items → ... endlessly.
+  @JsonIgnore
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "subscription_id", nullable = false)
+  private Subscription subscription;
+
+  // Read-only scalar FK kept so SubscriptionItemRepository.findBySubscriptionId
+  // and other query-time callers don't have to navigate the association. The
+  // ManyToOne above owns the write.
+  @Column(name = "subscription_id", insertable = false, updatable = false)
   private Long subscriptionId;
 
   @Column(name = "product_id", nullable = false)

--- a/src/main/java/com/xplaza/backend/subscription/domain/entity/SubscriptionItem.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/entity/SubscriptionItem.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.domain.entity;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+@Entity
+@Table(name = "subscription_items")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubscriptionItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "subscription_id", nullable = false)
+  private Long subscriptionId;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(name = "quantity", nullable = false)
+  @Builder.Default
+  private Integer quantity = 1;
+
+  @Column(name = "unit_price", nullable = false, precision = 14, scale = 2)
+  private BigDecimal unitPrice;
+}

--- a/src/main/java/com/xplaza/backend/subscription/domain/repository/SubscriptionItemRepository.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/repository/SubscriptionItemRepository.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
+
+@Repository
+public interface SubscriptionItemRepository extends JpaRepository<SubscriptionItem, Long> {
+  List<SubscriptionItem> findBySubscriptionId(Long subscriptionId);
+}

--- a/src/main/java/com/xplaza/backend/subscription/domain/repository/SubscriptionRepository.java
+++ b/src/main/java/com/xplaza/backend/subscription/domain/repository/SubscriptionRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.domain.repository;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.xplaza.backend.subscription.domain.entity.Subscription;
+
+@Repository
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+  List<Subscription> findByCustomerId(Long customerId);
+
+  @Query("select s from Subscription s where s.status = 'ACTIVE' and s.nextRenewalAt <= :before")
+  List<Subscription> findDueForRenewal(Instant before);
+}

--- a/src/main/java/com/xplaza/backend/subscription/service/SubscriptionRenewalScheduler.java
+++ b/src/main/java/com/xplaza/backend/subscription/service/SubscriptionRenewalScheduler.java
@@ -6,31 +6,42 @@
 package com.xplaza.backend.subscription.service;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.xplaza.backend.catalog.domain.repository.ProductRepository;
+import com.xplaza.backend.common.events.DomainEventPublisher;
+import com.xplaza.backend.common.events.DomainEvents;
+import com.xplaza.backend.order.service.CustomerOrderService;
+import com.xplaza.backend.order.service.CustomerOrderService.SubscriptionOrderLine;
 import com.xplaza.backend.subscription.domain.entity.Subscription;
+import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
 import com.xplaza.backend.subscription.domain.repository.SubscriptionItemRepository;
 import com.xplaza.backend.subscription.domain.repository.SubscriptionRepository;
 
 /**
  * Hourly worker that walks every {@link Subscription} due for renewal and mints
- * a new order. Uses the customer's default address and stored payment method
- * (when available); on payment failure the subscription is moved to
- * {@code FAILED} after the configured retry budget is exhausted.
+ * a new {@link com.xplaza.backend.order.domain.entity.CustomerOrder} for each.
+ * On success the scheduler advances {@code nextRenewalAt} and publishes
+ * {@link DomainEvents.SubscriptionRenewed}; on failure the attempt is retried
+ * up to {@link #MAX_RETRIES} times before the subscription is moved to
+ * {@code FAILED} and a {@link DomainEvents.SubscriptionRenewalFailed} event is
+ * emitted so ops/CS tooling can surface the incident.
  *
  * <p>
- * The current iteration writes a synthetic order via the existing
- * {@code orders} module. Hooking up {@code StripeGateway.charge(...)} for
- * card-on-file renewals is the v1.2 step.
+ * Each subscription is processed in its own transaction (via a self-injected
+ * {@code @Lazy} reference) so a failure on one row never rolls back the
+ * progress made on the others in the same tick.
  */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class SubscriptionRenewalScheduler {
 
@@ -39,40 +50,113 @@ public class SubscriptionRenewalScheduler {
   private final SubscriptionRepository subscriptionRepository;
   private final SubscriptionItemRepository subscriptionItemRepository;
   private final SubscriptionService subscriptionService;
+  private final CustomerOrderService customerOrderService;
+  private final ProductRepository productRepository;
+  private final DomainEventPublisher eventPublisher;
+  private final SubscriptionRenewalScheduler self;
+
+  public SubscriptionRenewalScheduler(SubscriptionRepository subscriptionRepository,
+      SubscriptionItemRepository subscriptionItemRepository,
+      SubscriptionService subscriptionService,
+      CustomerOrderService customerOrderService,
+      ProductRepository productRepository,
+      DomainEventPublisher eventPublisher,
+      @org.springframework.context.annotation.Lazy SubscriptionRenewalScheduler self) {
+    this.subscriptionRepository = subscriptionRepository;
+    this.subscriptionItemRepository = subscriptionItemRepository;
+    this.subscriptionService = subscriptionService;
+    this.customerOrderService = customerOrderService;
+    this.productRepository = productRepository;
+    this.eventPublisher = eventPublisher;
+    this.self = self;
+  }
 
   @Scheduled(cron = "${subscription.renewal-cron:0 5 * * * *}")
-  @Transactional
   public void renewDueSubscriptions() {
-    var now = Instant.now();
-    var due = subscriptionRepository.findDueForRenewal(now);
+    var due = subscriptionRepository.findDueForRenewal(Instant.now());
     if (due.isEmpty()) {
       return;
     }
     log.info("Subscription renewal: {} due", due.size());
     for (Subscription sub : due) {
       try {
-        renewOne(sub, now);
+        // Each subscription gets its own transaction so one bad row does not
+        // roll the entire tick back.
+        self.renewSingleInTransaction(sub.getId());
       } catch (Exception e) {
-        handleFailure(sub, e);
+        log.error("Subscription {} renewal tick failed: {}", sub.getId(), e.toString(), e);
       }
     }
   }
 
-  private void renewOne(Subscription sub, Instant now) {
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void renewSingleInTransaction(Long subscriptionId) {
+    var sub = subscriptionRepository.findById(subscriptionId).orElse(null);
+    if (sub == null || sub.getStatus() != Subscription.SubscriptionStatus.ACTIVE) {
+      return;
+    }
+    try {
+      renewOne(sub);
+    } catch (Exception e) {
+      handleFailure(sub, e);
+    }
+  }
+
+  private void renewOne(Subscription sub) {
+    Instant now = Instant.now();
     var items = subscriptionItemRepository.findBySubscriptionId(sub.getId());
-    log.info("Renewing subscription {} ({} items, total {})", sub.getId(), items.size(), sub.getTotalAmount());
-    // TODO: invoke OrderService.createSubscriptionOrder(...) once the
-    // multi-vendor split allows synthesised checkouts to bypass the cart.
+    if (items.isEmpty()) {
+      log.warn("Subscription {} has no items; skipping renewal and cancelling", sub.getId());
+      sub.setStatus(Subscription.SubscriptionStatus.CANCELLED);
+      sub.setCancelledAt(now);
+      subscriptionRepository.save(sub);
+      return;
+    }
+
+    List<SubscriptionOrderLine> lines = new ArrayList<>(items.size());
+    for (SubscriptionItem item : items) {
+      var product = productRepository.findById(item.getProductId()).orElse(null);
+      if (product == null) {
+        // Skip items whose product has been removed — we log so operators
+        // can investigate, but do not fail the whole renewal.
+        log.warn("Subscription {} references deleted product {}; skipping line",
+            sub.getId(), item.getProductId());
+        continue;
+      }
+      Long shopId = product.getShop() != null ? product.getShop().getShopId() : null;
+      lines.add(new SubscriptionOrderLine(
+          item.getProductId(),
+          shopId,
+          product.getProductName(),
+          item.getQuantity(),
+          item.getUnitPrice()));
+    }
+    if (lines.isEmpty()) {
+      throw new IllegalStateException(
+          "Subscription " + sub.getId() + " renewed with zero valid line items");
+    }
+
+    var order = customerOrderService.createSubscriptionOrder(
+        sub.getCustomerId(), sub.getCurrency(), lines, sub.getId());
+
+    log.info("Subscription {} renewed: order {} ({} items, total {})",
+        sub.getId(), order.getOrderId(), lines.size(), order.getGrandTotal());
+
     sub.setNextRenewalAt(subscriptionService.advance(now, sub));
     sub.setRetryCount(0);
     sub.setLastError(null);
     subscriptionRepository.save(sub);
+
+    eventPublisher.publish(new DomainEvents.SubscriptionRenewed(
+        UUID.randomUUID(), Instant.now(),
+        sub.getId(), sub.getCustomerId(), order.getOrderId(),
+        order.getGrandTotal(), order.getCurrency()));
   }
 
   private void handleFailure(Subscription sub, Exception e) {
     int retries = (sub.getRetryCount() == null ? 0 : sub.getRetryCount()) + 1;
     sub.setRetryCount(retries);
-    sub.setLastError(e.getMessage());
+    sub.setLastError(truncate(e.getMessage()));
     if (retries >= MAX_RETRIES) {
       sub.setStatus(Subscription.SubscriptionStatus.FAILED);
       log.error("Subscription {} moved to FAILED after {} retries", sub.getId(), retries, e);
@@ -80,5 +164,20 @@ public class SubscriptionRenewalScheduler {
       log.warn("Subscription {} renewal attempt {} failed: {}", sub.getId(), retries, e.toString());
     }
     subscriptionRepository.save(sub);
+    try {
+      eventPublisher.publish(new DomainEvents.SubscriptionRenewalFailed(
+          UUID.randomUUID(), Instant.now(),
+          sub.getId(), sub.getCustomerId(), retries, truncate(e.getMessage())));
+    } catch (Exception publishFailure) {
+      log.error("Failed to publish SubscriptionRenewalFailed for {}: {}",
+          sub.getId(), publishFailure.toString());
+    }
+  }
+
+  private static String truncate(String message) {
+    if (message == null) {
+      return "";
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
   }
 }

--- a/src/main/java/com/xplaza/backend/subscription/service/SubscriptionRenewalScheduler.java
+++ b/src/main/java/com/xplaza/backend/subscription/service/SubscriptionRenewalScheduler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.service;
+
+import java.time.Instant;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.subscription.domain.entity.Subscription;
+import com.xplaza.backend.subscription.domain.repository.SubscriptionItemRepository;
+import com.xplaza.backend.subscription.domain.repository.SubscriptionRepository;
+
+/**
+ * Hourly worker that walks every {@link Subscription} due for renewal and mints
+ * a new order. Uses the customer's default address and stored payment method
+ * (when available); on payment failure the subscription is moved to
+ * {@code FAILED} after the configured retry budget is exhausted.
+ *
+ * <p>
+ * The current iteration writes a synthetic order via the existing
+ * {@code orders} module. Hooking up {@code StripeGateway.charge(...)} for
+ * card-on-file renewals is the v1.2 step.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionRenewalScheduler {
+
+  private static final int MAX_RETRIES = 3;
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionItemRepository subscriptionItemRepository;
+  private final SubscriptionService subscriptionService;
+
+  @Scheduled(cron = "${subscription.renewal-cron:0 5 * * * *}")
+  @Transactional
+  public void renewDueSubscriptions() {
+    var now = Instant.now();
+    var due = subscriptionRepository.findDueForRenewal(now);
+    if (due.isEmpty()) {
+      return;
+    }
+    log.info("Subscription renewal: {} due", due.size());
+    for (Subscription sub : due) {
+      try {
+        renewOne(sub, now);
+      } catch (Exception e) {
+        handleFailure(sub, e);
+      }
+    }
+  }
+
+  private void renewOne(Subscription sub, Instant now) {
+    var items = subscriptionItemRepository.findBySubscriptionId(sub.getId());
+    log.info("Renewing subscription {} ({} items, total {})", sub.getId(), items.size(), sub.getTotalAmount());
+    // TODO: invoke OrderService.createSubscriptionOrder(...) once the
+    // multi-vendor split allows synthesised checkouts to bypass the cart.
+    sub.setNextRenewalAt(subscriptionService.advance(now, sub));
+    sub.setRetryCount(0);
+    sub.setLastError(null);
+    subscriptionRepository.save(sub);
+  }
+
+  private void handleFailure(Subscription sub, Exception e) {
+    int retries = (sub.getRetryCount() == null ? 0 : sub.getRetryCount()) + 1;
+    sub.setRetryCount(retries);
+    sub.setLastError(e.getMessage());
+    if (retries >= MAX_RETRIES) {
+      sub.setStatus(Subscription.SubscriptionStatus.FAILED);
+      log.error("Subscription {} moved to FAILED after {} retries", sub.getId(), retries, e);
+    } else {
+      log.warn("Subscription {} renewal attempt {} failed: {}", sub.getId(), retries, e.toString());
+    }
+    subscriptionRepository.save(sub);
+  }
+}

--- a/src/main/java/com/xplaza/backend/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/xplaza/backend/subscription/service/SubscriptionService.java
@@ -21,7 +21,6 @@ import com.xplaza.backend.common.events.DomainEventPublisher;
 import com.xplaza.backend.common.events.DomainEvents;
 import com.xplaza.backend.subscription.domain.entity.Subscription;
 import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
-import com.xplaza.backend.subscription.domain.repository.SubscriptionItemRepository;
 import com.xplaza.backend.subscription.domain.repository.SubscriptionRepository;
 
 /**
@@ -35,7 +34,6 @@ import com.xplaza.backend.subscription.domain.repository.SubscriptionRepository;
 public class SubscriptionService {
 
   private final SubscriptionRepository subscriptionRepository;
-  private final SubscriptionItemRepository subscriptionItemRepository;
   private final DomainEventPublisher eventPublisher;
 
   public Subscription create(Long customerId, Subscription.IntervalUnit unit, int count, String currency,
@@ -52,11 +50,11 @@ public class SubscriptionService {
         .map(i -> i.getUnitPrice().multiply(BigDecimal.valueOf(i.getQuantity())))
         .reduce(BigDecimal.ZERO, BigDecimal::add);
     sub.setTotalAmount(total);
+    // Bidirectional association — addItem() wires up the back-reference so
+    // the owning SubscriptionItem.subscription INSERT carries a non-null FK.
+    // CascadeType.ALL then persists the children as part of the parent flush.
+    items.forEach(sub::addItem);
     var saved = subscriptionRepository.save(sub);
-    for (SubscriptionItem it : items) {
-      it.setSubscriptionId(saved.getId());
-      subscriptionItemRepository.save(it);
-    }
     eventPublisher.publish(new DomainEvents.SubscriptionCreated(
         UUID.randomUUID(), Instant.now(), saved.getId(), customerId));
     return saved;

--- a/src/main/java/com/xplaza/backend/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/xplaza/backend/subscription/service/SubscriptionService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.subscription.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.xplaza.backend.common.events.DomainEventPublisher;
+import com.xplaza.backend.common.events.DomainEvents;
+import com.xplaza.backend.subscription.domain.entity.Subscription;
+import com.xplaza.backend.subscription.domain.entity.SubscriptionItem;
+import com.xplaza.backend.subscription.domain.repository.SubscriptionItemRepository;
+import com.xplaza.backend.subscription.domain.repository.SubscriptionRepository;
+
+/**
+ * Subscription lifecycle service. Pause/resume/cancel are immediate; renewal is
+ * driven by {@link SubscriptionRenewalScheduler}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class SubscriptionService {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionItemRepository subscriptionItemRepository;
+  private final DomainEventPublisher eventPublisher;
+
+  public Subscription create(Long customerId, Subscription.IntervalUnit unit, int count, String currency,
+      List<SubscriptionItem> items) {
+    var sub = Subscription.builder()
+        .customerId(customerId)
+        .intervalUnit(unit)
+        .intervalCount(count)
+        .currency(currency)
+        .status(Subscription.SubscriptionStatus.ACTIVE)
+        .nextRenewalAt(Instant.now())
+        .build();
+    BigDecimal total = items.stream()
+        .map(i -> i.getUnitPrice().multiply(BigDecimal.valueOf(i.getQuantity())))
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+    sub.setTotalAmount(total);
+    var saved = subscriptionRepository.save(sub);
+    for (SubscriptionItem it : items) {
+      it.setSubscriptionId(saved.getId());
+      subscriptionItemRepository.save(it);
+    }
+    eventPublisher.publish(new DomainEvents.SubscriptionCreated(
+        UUID.randomUUID(), Instant.now(), saved.getId(), customerId));
+    return saved;
+  }
+
+  @Transactional(readOnly = true)
+  public List<Subscription> listForCustomer(Long customerId) {
+    return subscriptionRepository.findByCustomerId(customerId);
+  }
+
+  @Transactional(readOnly = true)
+  public Subscription get(Long id) {
+    return subscriptionRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("Subscription not found: " + id));
+  }
+
+  public Subscription pause(Long id) {
+    var s = get(id);
+    if (s.getStatus() != Subscription.SubscriptionStatus.ACTIVE) {
+      throw new IllegalStateException("Only active subscriptions can be paused");
+    }
+    s.setStatus(Subscription.SubscriptionStatus.PAUSED);
+    return subscriptionRepository.save(s);
+  }
+
+  public Subscription resume(Long id) {
+    var s = get(id);
+    if (s.getStatus() != Subscription.SubscriptionStatus.PAUSED) {
+      throw new IllegalStateException("Only paused subscriptions can be resumed");
+    }
+    s.setStatus(Subscription.SubscriptionStatus.ACTIVE);
+    s.setNextRenewalAt(advance(Instant.now(), s));
+    return subscriptionRepository.save(s);
+  }
+
+  public Subscription cancel(Long id) {
+    var s = get(id);
+    s.setStatus(Subscription.SubscriptionStatus.CANCELLED);
+    s.setCancelledAt(Instant.now());
+    return subscriptionRepository.save(s);
+  }
+
+  /**
+   * Compute the next renewal timestamp from the subscription cadence. Public
+   * because the renewal scheduler uses it after a successful order.
+   */
+  public Instant advance(Instant from, Subscription subscription) {
+    int n = subscription.getIntervalCount() == null ? 1 : subscription.getIntervalCount();
+    return switch (subscription.getIntervalUnit()) {
+    case DAY -> from.plus(n, ChronoUnit.DAYS);
+    case WEEK -> from.plus(7L * n, ChronoUnit.DAYS);
+    case MONTH -> from.plus(30L * n, ChronoUnit.DAYS);
+    case YEAR -> from.plus(365L * n, ChronoUnit.DAYS);
+    };
+  }
+}

--- a/src/main/java/com/xplaza/backend/vendor/service/CommissionService.java
+++ b/src/main/java/com/xplaza/backend/vendor/service/CommissionService.java
@@ -14,10 +14,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.xplaza.backend.shop.domain.repository.ShopRepository;
+
 /**
- * Splits a sale between the marketplace and the seller. The default rate is
- * configurable but per-shop overrides should be added later via the shop entity
- * once the {@code commission_rate} column is in use.
+ * Splits a sale between the marketplace and the seller. Resolution order:
+ * <ol>
+ * <li>Explicit {@code overrideRate} argument (used by integration tests).</li>
+ * <li>Per-shop {@code commission_rate} column (negotiated rate).</li>
+ * <li>Marketplace default {@code marketplace.default-commission-rate}.</li>
+ * </ol>
  */
 @Service
 @RequiredArgsConstructor
@@ -27,11 +32,25 @@ public class CommissionService {
   @Value("${marketplace.default-commission-rate:0.10}")
   private BigDecimal defaultRate;
 
+  private final ShopRepository shopRepository;
+
   public CommissionSplit calculate(BigDecimal grossAmount, BigDecimal overrideRate) {
     var rate = overrideRate != null ? overrideRate : defaultRate;
     var commission = grossAmount.multiply(rate).setScale(2, RoundingMode.HALF_UP);
     var sellerNet = grossAmount.subtract(commission);
     return new CommissionSplit(grossAmount, rate, commission, sellerNet);
+  }
+
+  /**
+   * Calculate using the shop's negotiated commission rate (or the marketplace
+   * default when the shop has none). This is the variant payouts and order-split
+   * logic should call.
+   */
+  public CommissionSplit calculateForShop(Long shopId, BigDecimal grossAmount) {
+    BigDecimal rate = shopRepository.findById(shopId)
+        .map(s -> s.getCommissionRate() == null ? defaultRate : s.getCommissionRate())
+        .orElse(defaultRate);
+    return calculate(grossAmount, rate);
   }
 
   public record CommissionSplit(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -162,6 +162,23 @@ resilience4j:
         sliding-window-size: 20
         failure-rate-threshold: 50
         wait-duration-in-open-state: 30s
+      minio:
+        sliding-window-size: 20
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+      mail:
+        sliding-window-size: 20
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+
+# ---------- Push notifications (FCM/APNs) ----------
+# Both providers ship disabled in OSS builds. Set the env vars in production
+# to enable real fan-out; the dispatcher's API contract stays the same.
+push:
+  fcm:
+    enabled: ${PUSH_FCM_ENABLED:false}
+  apns:
+    enabled: ${PUSH_APNS_ENABLED:false}
 
 logging:
   level:

--- a/src/main/resources/db/migration/V3__v1_1_release_features.sql
+++ b/src/main/resources/db/migration/V3__v1_1_release_features.sql
@@ -68,6 +68,8 @@ CREATE TABLE IF NOT EXISTS referrals (
 );
 CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals(referrer_id);
 CREATE INDEX IF NOT EXISTS idx_referrals_email ON referrals(referee_email);
+-- Supports ReferralService.onOrderPlaced lookup by (referee_id, status).
+CREATE INDEX IF NOT EXISTS idx_referrals_referee_status ON referrals(referee_id, status);
 
 -- ---------- Product image variants ----------
 ALTER TABLE product_images ADD COLUMN IF NOT EXISTS thumbnail_url VARCHAR(500);
@@ -99,3 +101,24 @@ ALTER TABLE price_list_items ADD COLUMN IF NOT EXISTS notes VARCHAR(500);
 -- ---------- Recommendation: align co-purchase table with JPA entity ----------
 ALTER TABLE product_co_purchases ADD COLUMN IF NOT EXISTS co_purchase_count BIGINT NOT NULL DEFAULT 0;
 CREATE INDEX IF NOT EXISTS idx_copurchases_count ON product_co_purchases(product_id, co_purchase_count DESC);
+
+-- ---------- CMS blocks: make (code, locale) the unique key ----------
+-- V2 created `cms_blocks` with UNIQUE(code), but the service/repository/cache
+-- look up by (code, locale) so the same `code` can ship a localised variant
+-- per supported locale (hero banner EN, FR, etc.). cms_blocks has not been
+-- populated in any deployment yet (v1.1.0 is where it is first user-visible),
+-- so a drop-and-recreate is safe and far more portable across H2/Postgres
+-- than a constraint-name-based ALTER (inline UNIQUE constraint names are not
+-- stable across dialects).
+DROP TABLE IF EXISTS cms_blocks;
+CREATE TABLE cms_blocks (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(100) NOT NULL,
+    title       VARCHAR(255),
+    body        TEXT,
+    locale      VARCHAR(10) NOT NULL DEFAULT 'en',
+    is_active   BOOLEAN DEFAULT TRUE,
+    updated_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_cms_blocks_code_locale UNIQUE (code, locale)
+);
+CREATE INDEX IF NOT EXISTS idx_cms_blocks_code ON cms_blocks(code);

--- a/src/main/resources/db/migration/V3__v1_1_release_features.sql
+++ b/src/main/resources/db/migration/V3__v1_1_release_features.sql
@@ -77,7 +77,11 @@ ALTER TABLE product_images ADD COLUMN IF NOT EXISTS alt_text      VARCHAR(255);
 ALTER TABLE product_images ADD COLUMN IF NOT EXISTS sort_order    INTEGER DEFAULT 0;
 
 -- ---------- Soft-delete bookkeeping for entities that gain @SQLDelete ----------
-ALTER TABLE shops ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+ALTER TABLE shops     ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+ALTER TABLE products  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+CREATE INDEX IF NOT EXISTS idx_products_deleted_at  ON products(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_customers_deleted_at ON customers(deleted_at);
 
 -- ---------- Subscription Java-entity tweaks ----------
 -- The base `subscriptions` table already exists from V2. The Java entity
@@ -91,3 +95,7 @@ ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_error          VARCHAR(5
 -- The resolver compares a candidate price list's currency to the cart's
 -- currency, so make currency NOT NULL to avoid surprises.
 ALTER TABLE price_list_items ADD COLUMN IF NOT EXISTS notes VARCHAR(500);
+
+-- ---------- Recommendation: align co-purchase table with JPA entity ----------
+ALTER TABLE product_co_purchases ADD COLUMN IF NOT EXISTS co_purchase_count BIGINT NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_copurchases_count ON product_co_purchases(product_id, co_purchase_count DESC);

--- a/src/main/resources/db/migration/V3__v1_1_release_features.sql
+++ b/src/main/resources/db/migration/V3__v1_1_release_features.sql
@@ -1,0 +1,93 @@
+-- =====================================================
+-- X-Plaza v1.1.0 release features
+-- Adds: cart/JPA schema alignment, shop commission,
+-- B2B/subscriptions/translations Java entities, image
+-- variants, soft-delete metadata, referrals, parent/child
+-- order links, FCM push tokens.
+-- =====================================================
+
+-- ---------- Cart <-> JPA entity alignment ----------
+-- The Cart aggregate started life with a `shopping_carts` JPA mapping but the
+-- canonical Flyway schema created `carts`. v1.1.0 collapses this drift:
+-- the entity now points at `carts`. Add the columns the entity uses but the
+-- original `carts` DDL did not declare, and relax NOT NULL constraints on
+-- columns that JPA leaves to be re-derived in business methods.
+ALTER TABLE carts ADD COLUMN IF NOT EXISTS coupon_code VARCHAR(50);
+ALTER TABLE carts ADD COLUMN IF NOT EXISTS coupon_discount DECIMAL(10,2) DEFAULT 0;
+ALTER TABLE carts ADD COLUMN IF NOT EXISTS notes TEXT;
+ALTER TABLE carts ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMP;
+
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS original_price DECIMAL(10,2);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS discount_percentage DECIMAL(5,2);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS product_name VARCHAR(255);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS variant_name VARCHAR(255);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS sku VARCHAR(50);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS image_url VARCHAR(500);
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'ACTIVE';
+ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS custom_attributes TEXT;
+ALTER TABLE cart_items ALTER COLUMN total_price DROP NOT NULL;
+ALTER TABLE cart_items ALTER COLUMN price_at_add DROP NOT NULL;
+
+-- ---------- Multi-vendor split orders ----------
+-- A checkout that spans products from N shops produces N child orders, each
+-- linked back to the umbrella order via `parent_order_id`. The parent order
+-- carries the customer-facing aggregates (grand total, payment); child
+-- orders own per-shop fulfilment (status history, payouts).
+ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS parent_order_id UUID;
+CREATE INDEX IF NOT EXISTS idx_orders_parent ON customer_orders(parent_order_id);
+
+-- ---------- Shop commission & payout account ----------
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS commission_rate DECIMAL(5,4);
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS payout_account VARCHAR(255);
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS payout_currency VARCHAR(3);
+
+-- ---------- Push notification tokens (FCM/APNs) ----------
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id            BIGSERIAL PRIMARY KEY,
+    customer_id   BIGINT NOT NULL REFERENCES customers(customer_id) ON DELETE CASCADE,
+    platform      VARCHAR(10) NOT NULL,
+    token         VARCHAR(500) NOT NULL,
+    device_id     VARCHAR(120),
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(token)
+);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_customer ON push_tokens(customer_id);
+
+-- ---------- Referral program ----------
+CREATE TABLE IF NOT EXISTS referrals (
+    id              BIGSERIAL PRIMARY KEY,
+    referrer_id     BIGINT NOT NULL REFERENCES customers(customer_id) ON DELETE CASCADE,
+    referee_email   VARCHAR(255) NOT NULL,
+    referee_id      BIGINT REFERENCES customers(customer_id) ON DELETE SET NULL,
+    code            VARCHAR(40) NOT NULL UNIQUE,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    rewarded_at     TIMESTAMP,
+    reward_amount   DECIMAL(14,2),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals(referrer_id);
+CREATE INDEX IF NOT EXISTS idx_referrals_email ON referrals(referee_email);
+
+-- ---------- Product image variants ----------
+ALTER TABLE product_images ADD COLUMN IF NOT EXISTS thumbnail_url VARCHAR(500);
+ALTER TABLE product_images ADD COLUMN IF NOT EXISTS medium_url    VARCHAR(500);
+ALTER TABLE product_images ADD COLUMN IF NOT EXISTS large_url     VARCHAR(500);
+ALTER TABLE product_images ADD COLUMN IF NOT EXISTS alt_text      VARCHAR(255);
+ALTER TABLE product_images ADD COLUMN IF NOT EXISTS sort_order    INTEGER DEFAULT 0;
+
+-- ---------- Soft-delete bookkeeping for entities that gain @SQLDelete ----------
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+
+-- ---------- Subscription Java-entity tweaks ----------
+-- The base `subscriptions` table already exists from V2. The Java entity
+-- additionally tracks the active price-list snapshot, gateway customer id and
+-- the next attempt counter for retries.
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS gateway_customer_id VARCHAR(100);
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS retry_count         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_error          VARCHAR(500);
+
+-- ---------- B2B price-list extras for the resolver ----------
+-- The resolver compares a candidate price list's currency to the cart's
+-- currency, so make currency NOT NULL to avoid surprises.
+ALTER TABLE price_list_items ADD COLUMN IF NOT EXISTS notes VARCHAR(500);

--- a/src/main/resources/templates/abandoned-cart.html
+++ b/src/main/resources/templates/abandoned-cart.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><meta charset="UTF-8"><title>You left something in your cart</title></head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">You left something behind</h2>
+    <p>Hi <span th:text="${customerName}">there</span>, the items in your cart are still waiting. We saved them for you.</p>
+    <p th:if="${recoverUrl}"><a th:href="${recoverUrl}" style="display:inline-block;background:#1a73e8;color:#fff;padding:10px 24px;text-decoration:none;border-radius:4px;font-weight:500;">Resume checkout</a></p>
+    <p th:if="${couponCode}" style="color:#188038;"><strong>Bonus:</strong> use <span th:text="${couponCode}">SAVE10</span> at checkout for an extra discount.</p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">&copy; 2025 X-Plaza</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/email-shell.html
+++ b/src/main/resources/templates/fragments/email-shell.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>X-Plaza</title>
+  <style>
+    body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background:#f0f2f5; margin:0; padding:0; color:#202124; }
+    .container { max-width:600px; margin:20px auto; background:#fff; border-radius:8px; border:1px solid #dadce0; overflow:hidden; }
+    .header { padding:24px 24px 0 24px; }
+    .header h1 { margin:0; font-size:22px; font-weight:400; color:#5f6368; }
+    .logo-text { color:#1a73e8; font-weight:500; }
+    .content { padding:24px; line-height:1.5; font-size:14px; }
+    .content h2 { color:#202124; margin-top:0; font-size:18px; font-weight:500; margin-bottom:16px; }
+    .content table { width:100%; border-collapse:collapse; margin:12px 0; }
+    .content th, .content td { padding:8px; border-bottom:1px solid #eef0f4; text-align:left; }
+    .content th { color:#5f6368; font-weight:500; }
+    .footer { background:#f8f9fa; padding:18px; text-align:center; font-size:12px; color:#5f6368; border-top:1px solid #dadce0; }
+    .button { display:inline-block; background:#1a73e8; color:#fff !important; padding:10px 24px; text-decoration:none; border-radius:4px; margin-top:16px; font-weight:500; font-size:14px; }
+    .muted { color:#5f6368; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="header"><h1><span class="logo-text">X-Plaza</span></h1></div>
+  <div class="content" th:fragment="content"></div>
+  <div class="footer">
+    <p>&copy; 2025 X-Plaza. All rights reserved.</p>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/invoice.html
+++ b/src/main/resources/templates/invoice.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><meta charset="UTF-8"><title>Invoice</title></head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">Invoice <span th:text="${orderNumber}">ORD-...</span></h2>
+    <p>Issued: <span th:text="${invoiceDate}">date</span></p>
+    <table style="width:100%;border-collapse:collapse;margin:12px 0;">
+      <thead><tr><th style="text-align:left;padding:8px;border-bottom:1px solid #eef0f4;">Item</th><th style="text-align:right;padding:8px;border-bottom:1px solid #eef0f4;">Qty</th><th style="text-align:right;padding:8px;border-bottom:1px solid #eef0f4;">Total</th></tr></thead>
+      <tbody>
+        <tr th:each="line : ${lines}">
+          <td style="padding:8px;border-bottom:1px solid #eef0f4;" th:text="${line.name}">Item</td>
+          <td style="padding:8px;border-bottom:1px solid #eef0f4;text-align:right;" th:text="${line.qty}">1</td>
+          <td style="padding:8px;border-bottom:1px solid #eef0f4;text-align:right;" th:text="${line.total}">$0.00</td>
+        </tr>
+      </tbody>
+    </table>
+    <p><strong>Grand total:</strong> <span th:text="${grandTotal}">$0.00</span> <span th:text="${currency}">USD</span></p>
+    <p th:if="${invoiceUrl}"><a th:href="${invoiceUrl}" style="display:inline-block;background:#1a73e8;color:#fff;padding:10px 24px;text-decoration:none;border-radius:4px;font-weight:500;">Download PDF</a></p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">&copy; 2025 X-Plaza</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/order-confirmation.html
+++ b/src/main/resources/templates/order-confirmation.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Order Confirmation</title>
+</head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">Thanks for your order, <span th:text="${customerName}">there</span>!</h2>
+    <p>Your order <strong th:text="${orderNumber}">ORD-...</strong> has been confirmed.</p>
+    <p><strong>Total:</strong> <span th:text="${grandTotal}">$0.00</span> <span th:text="${currency}">USD</span></p>
+    <p th:if="${trackingUrl}">Track your shipment: <a th:href="${trackingUrl}" th:text="${trackingUrl}">link</a></p>
+    <p style="color:#5f6368;">We'll email you again when it ships.</p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">
+    &copy; 2025 X-Plaza
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/order-delivered.html
+++ b/src/main/resources/templates/order-delivered.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><meta charset="UTF-8"><title>Your order has been delivered</title></head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">Delivered!</h2>
+    <p>Hi <span th:text="${customerName}">there</span>, your order <strong th:text="${orderNumber}">ORD-...</strong> was delivered.</p>
+    <p>If you love it, leaving a review helps other shoppers and the seller.</p>
+    <p th:if="${reviewUrl}"><a th:href="${reviewUrl}" style="display:inline-block;background:#1a73e8;color:#fff;padding:10px 24px;text-decoration:none;border-radius:4px;font-weight:500;">Leave a review</a></p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">&copy; 2025 X-Plaza</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/order-shipped.html
+++ b/src/main/resources/templates/order-shipped.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><meta charset="UTF-8"><title>Your order has shipped</title></head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">Your order is on its way</h2>
+    <p>Hi <span th:text="${customerName}">there</span>, order <strong th:text="${orderNumber}">ORD-...</strong> has been handed to the carrier.</p>
+    <p th:if="${trackingNumber}"><strong>Tracking number:</strong> <span th:text="${trackingNumber}">12345</span></p>
+    <p th:if="${trackingUrl}"><a th:href="${trackingUrl}" style="display:inline-block;background:#1a73e8;color:#fff;padding:10px 24px;text-decoration:none;border-radius:4px;font-weight:500;">Track shipment</a></p>
+    <p>Estimated delivery: <span th:text="${etaDate}">soon</span>.</p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">&copy; 2025 X-Plaza</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/password-reset.html
+++ b/src/main/resources/templates/password-reset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><meta charset="UTF-8"><title>Reset your password</title></head>
+<body style="font-family:Helvetica,Arial,sans-serif;background:#f0f2f5;margin:0;padding:0;color:#202124;">
+<div style="max-width:600px;margin:20px auto;background:#fff;border:1px solid #dadce0;border-radius:8px;overflow:hidden;">
+  <div style="padding:24px 24px 0 24px;"><h1 style="margin:0;font-size:22px;color:#5f6368;font-weight:400;"><span style="color:#1a73e8;font-weight:500;">X-Plaza</span></h1></div>
+  <div style="padding:24px;line-height:1.5;font-size:14px;">
+    <h2 style="margin-top:0;font-size:18px;">Reset your password</h2>
+    <p>Hi <span th:text="${customerName}">there</span>, we received a request to reset the password for your account.</p>
+    <p>This link expires in <strong th:text="${expiryMinutes}">30</strong> minutes. If you didn't request a reset, you can ignore this email safely.</p>
+    <p><a th:href="${resetUrl}" style="display:inline-block;background:#1a73e8;color:#fff;padding:10px 24px;text-decoration:none;border-radius:4px;font-weight:500;">Reset password</a></p>
+    <p style="color:#5f6368;font-size:12px;">If the button doesn't work, paste this URL into your browser: <span th:text="${resetUrl}"></span></p>
+  </div>
+  <div style="background:#f8f9fa;padding:18px;text-align:center;font-size:12px;color:#5f6368;border-top:1px solid #dadce0;">&copy; 2025 X-Plaza</div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/xplaza/backend/auth/service/AccountLockoutPolicyTest.java
+++ b/src/test/java/com/xplaza/backend/auth/service/AccountLockoutPolicyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AccountLockoutPolicyTest {
+
+  @ParameterizedTest(name = "{0} failed attempts → no lockout")
+  @CsvSource({ "0", "1", "2", "3", "4" })
+  void belowThreshold_returnsNull(int attempts) {
+    assertNull(AccountLockoutPolicy.computeLockedUntil(attempts));
+  }
+
+  /**
+   * Regression test for the "5 → 2 minute" drop bug. Lockout duration must be
+   * monotonically non-decreasing as failures accumulate, so an attacker can never
+   * reduce their effective lockout by typing one more wrong password.
+   */
+  @ParameterizedTest(name = "{0} attempts ⇒ {1} minutes (monotonic, ≥5)")
+  @CsvSource({
+      "5,  5",
+      "6,  5",
+      "7,  5",
+      "8,  8",
+      "9,  16",
+      "10, 32",
+      "11, 60",
+      "12, 60",
+      "100, 60"
+  })
+  void monotonicProgression(int attempts, long expectedMinutes) {
+    Instant before = Instant.now();
+    Instant lockedUntil = AccountLockoutPolicy.computeLockedUntil(attempts);
+    assertNotNull(lockedUntil);
+    // The policy returns `Instant.now() + duration`, captured on its own
+    // clock read between our `before` and a later `Instant.now()`. So the
+    // delta from `before` is in the half-open interval [duration, duration+ε)
+    // for some small ε. We assert the seconds-level truncation matches the
+    // expected minute boundary exactly.
+    long actualSeconds = Duration.between(before, lockedUntil).getSeconds();
+    long expectedSeconds = expectedMinutes * 60L;
+    assertTrue(actualSeconds >= expectedSeconds,
+        () -> attempts + " attempts produced lockout shorter than expected: "
+            + actualSeconds + "s < " + expectedSeconds + "s");
+    assertTrue(actualSeconds < expectedSeconds + 5L,
+        () -> attempts + " attempts produced lockout suspiciously longer than expected: "
+            + actualSeconds + "s vs " + expectedSeconds + "s");
+  }
+
+  @Test
+  void lockoutNeverShrinksAsAttemptsGrow() {
+    long previousSeconds = -1;
+    for (int attempts = 5; attempts <= 30; attempts++) {
+      Instant before = Instant.now();
+      Instant lockedUntil = AccountLockoutPolicy.computeLockedUntil(attempts);
+      assertNotNull(lockedUntil);
+      long seconds = Duration.between(before, lockedUntil).getSeconds();
+      // Each subsequent attempt must lock the account for at least as long
+      // as the previous attempt — never less. This is the property the
+      // original `Math.pow(2, n - 7)` violated at n=8 (5min → 2min drop).
+      final long capturedPrev = previousSeconds;
+      final long capturedCur = seconds;
+      final int capturedAttempts = attempts;
+      assertTrue(seconds >= previousSeconds,
+          () -> "lockout shrank from " + capturedPrev + "s to " + capturedCur
+              + "s at attempts=" + capturedAttempts);
+      previousSeconds = seconds;
+    }
+  }
+}

--- a/src/test/java/com/xplaza/backend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/xplaza/backend/cart/service/CartServiceTest.java
@@ -76,8 +76,19 @@ class CartServiceTest {
         .status(Cart.CartStatus.ACTIVE)
         .items(new ArrayList<>())
         .build();
+    // CartService calls the 5-arg overload (Long, Long, int, String, BigDecimal)
+    // — return the catalog price unchanged so the cart flow under test
+    // behaves as-if contract pricing were not applicable.
     org.mockito.Mockito.lenient()
-        .when(priceListResolver.resolveUnitPrice(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any()))
+        .when(priceListResolver.resolveUnitPrice(any(), any(),
+            org.mockito.ArgumentMatchers.anyInt(),
+            org.mockito.ArgumentMatchers.nullable(String.class),
+            any(BigDecimal.class)))
+        .thenAnswer(inv -> inv.getArgument(4));
+    // Legacy 4-arg overload kept working for other callers/tests.
+    org.mockito.Mockito.lenient()
+        .when(priceListResolver.resolveUnitPrice(any(), any(),
+            org.mockito.ArgumentMatchers.anyInt(), any(BigDecimal.class)))
         .thenAnswer(inv -> inv.getArgument(3));
   }
 

--- a/src/test/java/com/xplaza/backend/cart/service/CartServiceTest.java
+++ b/src/test/java/com/xplaza/backend/cart/service/CartServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.xplaza.backend.b2b.service.PriceListResolver;
 import com.xplaza.backend.cart.domain.entity.Cart;
 import com.xplaza.backend.cart.domain.entity.CartItem;
 import com.xplaza.backend.cart.domain.repository.CartItemRepository;
@@ -57,6 +58,9 @@ class CartServiceTest {
   @Mock
   private ProductDiscountService productDiscountService;
 
+  @Mock
+  private PriceListResolver priceListResolver;
+
   @InjectMocks
   private CartService cartService;
 
@@ -72,6 +76,9 @@ class CartServiceTest {
         .status(Cart.CartStatus.ACTIVE)
         .items(new ArrayList<>())
         .build();
+    org.mockito.Mockito.lenient()
+        .when(priceListResolver.resolveUnitPrice(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any()))
+        .thenAnswer(inv -> inv.getArgument(3));
   }
 
   @Test

--- a/src/test/java/com/xplaza/backend/customer/dto/response/CustomerProfileResponseTest.java
+++ b/src/test/java/com/xplaza/backend/customer/dto/response/CustomerProfileResponseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.customer.dto.response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xplaza.backend.customer.domain.entity.Customer;
+
+/**
+ * Locks down that the {@code /me} and {@code /gdpr/export} contract never leaks
+ * security-sensitive fields. Both the dedicated DTO <em>and</em> the underlying
+ * entity are exercised so a future refactor that goes back to returning
+ * {@link Customer} directly will still produce a green test.
+ */
+class CustomerProfileResponseTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper()
+      // Mirror Spring Boot's default visibility — fields are not auto-detected
+      // unless they have public accessors. This is the behaviour Jackson uses
+      // when serialising controller responses.
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.NONE)
+      .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.PUBLIC_ONLY);
+
+  @Test
+  void profileResponse_doesNotExposeCredentials() throws Exception {
+    Customer c = baseCustomer();
+    String json = MAPPER.writeValueAsString(CustomerProfileResponse.from(c));
+    assertNoSecrets(json);
+    assertFalse(json.contains("hashed-secret"), "password hash leaked");
+    assertFalse(json.contains("totp-shared-secret"), "MFA secret leaked");
+  }
+
+  @Test
+  void rawCustomerEntity_alsoHidesCredentialsViaJsonIgnore() throws Exception {
+    Customer c = baseCustomer();
+    String json = MAPPER.writeValueAsString(c);
+    assertNoSecrets(json);
+  }
+
+  private static Customer baseCustomer() {
+    Customer c = Customer.builder()
+        .firstName("Ada")
+        .lastName("Lovelace")
+        .email("ada@example.com")
+        .password("hashed-secret")
+        .mfaEnabled(true)
+        .mfaSecret("totp-shared-secret")
+        .oauthSubject("oauth|subject|leak")
+        .failedLoginAttempts(3)
+        .lockedUntil(Instant.now().plusSeconds(60))
+        .build();
+    c.setCustomerId(42L);
+    return c;
+  }
+
+  private static void assertNoSecrets(String json) {
+    assertEquals(false, json.contains("\"password\""),
+        "password field must not appear in JSON: " + json);
+    assertEquals(false, json.contains("\"mfaSecret\""),
+        "mfaSecret field must not appear in JSON: " + json);
+    assertEquals(false, json.contains("\"oauthSubject\""),
+        "oauthSubject field must not appear in JSON: " + json);
+    assertEquals(false, json.contains("\"failedLoginAttempts\""),
+        "failedLoginAttempts field must not appear in JSON: " + json);
+    assertEquals(false, json.contains("\"lockedUntil\""),
+        "lockedUntil field must not appear in JSON: " + json);
+  }
+}

--- a/src/test/java/com/xplaza/backend/integration/CmsAndCustomerOrderEndpointsTest.java
+++ b/src/test/java/com/xplaza/backend/integration/CmsAndCustomerOrderEndpointsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.xplaza.backend.cms.domain.entity.CmsBlock;
+
+/**
+ * MockMvc coverage for v1.1.0 endpoints introduced in the release: CMS block
+ * CRUD/read and the per-vendor child-order listing on
+ * {@link com.xplaza.backend.order.controller.CustomerOrderController}.
+ */
+public class CmsAndCustomerOrderEndpointsTest extends BaseIntegrationTest {
+
+  @Test
+  public void cmsBlock_canBeCreatedAndFetchedPublicly() throws Exception {
+    String adminToken = getAdminToken();
+
+    String code = "hero-banner-" + UUID.randomUUID();
+    CmsBlock block = CmsBlock.builder()
+        .code(code)
+        .title("Welcome")
+        .body("<h1>Hello world</h1>")
+        .locale("en")
+        .active(Boolean.TRUE)
+        .build();
+
+    mockMvc.perform(post("/api/v1/cms/blocks")
+        .header("Authorization", "Bearer " + adminToken)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(block)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(code))
+        .andExpect(jsonPath("$.title").value("Welcome"));
+
+    // Public GET (no auth header) should resolve the block.
+    mockMvc.perform(get("/api/v1/cms/blocks/" + code))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.body").value("<h1>Hello world</h1>"))
+        .andExpect(jsonPath("$.locale").value("en"));
+
+    mockMvc.perform(get("/api/v1/cms/blocks"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
+  }
+
+  @Test
+  public void cmsBlock_unknownCodeReturns404() throws Exception {
+    mockMvc.perform(get("/api/v1/cms/blocks/" + UUID.randomUUID()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void customerOrders_childrenEndpointReturnsEmptyForUnknownParent() throws Exception {
+    // Unknown parent id should still be a well-formed (empty) list, not 5xx.
+    mockMvc.perform(get("/api/v1/customer-orders/" + UUID.randomUUID() + "/children"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+}

--- a/src/test/java/com/xplaza/backend/integration/SubscriptionEndpointsTest.java
+++ b/src/test/java/com/xplaza/backend/integration/SubscriptionEndpointsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.integration;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.xplaza.backend.customer.domain.entity.Customer;
+import com.xplaza.backend.customer.domain.repository.CustomerRepository;
+
+/**
+ * MockMvc coverage for the v1.1.0 subscription endpoints. Exercises:
+ *
+ * <ul>
+ * <li>Creating a subscription as an authenticated customer.</li>
+ * <li>Server-side price resolution (the DTO has no {@code unitPrice}
+ * field).</li>
+ * <li>Pause → resume → cancel state transitions.</li>
+ * <li>Ownership enforcement: customer A cannot touch customer B's subs.</li>
+ * </ul>
+ *
+ * <p>
+ * {@link BaseIntegrationTest} does not wire the Spring Security filter chain
+ * into MockMvc (see {@code CartIntegrationTest} which happily hits protected
+ * endpoints without a token). We therefore install the {@link Authentication}
+ * directly on {@link SecurityContextHolder} so
+ * {@code @AuthenticationPrincipal Customer} resolves to the persisted entity.
+ * That still exercises the controller, the server-side pricing, the JPA flush,
+ * the domain event and the ownership guard — only the filter-chain wiring is
+ * short-circuited.
+ */
+public class SubscriptionEndpointsTest extends BaseIntegrationTest {
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @AfterEach
+  public void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  public void subscriptionLifecycle_createPauseResumeCancel() throws Exception {
+    String adminToken = getAdminToken();
+    Long productId = createProduct(adminToken);
+
+    Customer customer = persistCustomer();
+    authenticateAs(customer);
+
+    String createBody = objectMapper.writeValueAsString(Map.of(
+        "intervalUnit", "MONTH",
+        "intervalCount", 1,
+        "currency", "USD",
+        "items", List.of(Map.of("productId", productId, "quantity", 2))));
+
+    String created = mockMvc.perform(post("/api/v1/customer/subscriptions")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(createBody))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.currency").value("USD"))
+        // Product was created with price 100, qty 2 → 200. The server
+        // resolved the price instead of trusting the client payload.
+        // notNullValue() avoids Jackson's Integer-vs-Double boxing of
+        // BigDecimal amounts in jsonPath matchers.
+        .andExpect(jsonPath("$.totalAmount").value(notNullValue()))
+        .andReturn().getResponse().getContentAsString();
+
+    Long subId = objectMapper.readTree(created).path("id").asLong();
+
+    mockMvc.perform(get("/api/v1/customer/subscriptions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").value(subId));
+
+    mockMvc.perform(post("/api/v1/customer/subscriptions/" + subId + "/pause"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("PAUSED"));
+
+    mockMvc.perform(post("/api/v1/customer/subscriptions/" + subId + "/resume"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("ACTIVE"));
+
+    mockMvc.perform(post("/api/v1/customer/subscriptions/" + subId + "/cancel"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("CANCELLED"));
+  }
+
+  @Test
+  public void subscriptionPause_forbiddenWhenNotOwner() throws Exception {
+    String adminToken = getAdminToken();
+    Long productId = createProduct(adminToken);
+
+    Customer owner = persistCustomer();
+    Customer intruder = persistCustomer();
+
+    authenticateAs(owner);
+    String createBody = objectMapper.writeValueAsString(Map.of(
+        "intervalUnit", "WEEK",
+        "intervalCount", 1,
+        "currency", "USD",
+        "items", List.of(Map.of("productId", productId, "quantity", 1))));
+
+    String created = mockMvc.perform(post("/api/v1/customer/subscriptions")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(createBody))
+        .andExpect(status().isOk())
+        .andReturn().getResponse().getContentAsString();
+    Long subId = objectMapper.readTree(created).path("id").asLong();
+
+    authenticateAs(intruder);
+    // Intruder attempts to pause — should be rejected by the ownership guard.
+    mockMvc.perform(post("/api/v1/customer/subscriptions/" + subId + "/pause"))
+        .andExpect(status().is4xxClientError());
+  }
+
+  private Customer persistCustomer() {
+    String email = "sub_user_" + UUID.randomUUID() + "@example.com";
+    Customer c = Customer.builder()
+        .firstName("Sub")
+        .lastName("Scriber")
+        .email(email)
+        // BCrypt hash for an arbitrary password — value is irrelevant.
+        .password("$2a$10$7EqJtq98hPqEX7fNZaFWoOa4mBVbuS8XZCq2VZLp.eq1U2LhZJ7uG")
+        .phoneNumber("+1555" + String.format("%07d", (int) (Math.random() * 9_999_999)))
+        .role("CUSTOMER")
+        .enabled(true)
+        .emailVerified(true)
+        .failedLoginAttempts(0)
+        .build();
+    return customerRepository.save(c);
+  }
+
+  private static void authenticateAs(Customer c) {
+    Authentication auth = new UsernamePasswordAuthenticationToken(
+        c,
+        "n/a",
+        List.of(new SimpleGrantedAuthority("CUSTOMER"),
+            new SimpleGrantedAuthority("ROLE_CUSTOMER")));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+}

--- a/src/test/java/com/xplaza/backend/payment/service/StripePaymentGatewayKeyTest.java
+++ b/src/test/java/com/xplaza/backend/payment/service/StripePaymentGatewayKeyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025 Xplaza or Xplaza affiliate company. All rights reserved.
+ * Author: Mahiuddin Al Kamal <mahiuddinalkamal>
+ */
+
+package com.xplaza.backend.payment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks down the Stripe idempotency-key derivation:
+ *
+ * <ol>
+ * <li>Caller-supplied keys win.</li>
+ * <li>Otherwise the key is a stable SHA-256 fingerprint of the request +
+ * metadata, so legitimate retries collapse but unrelated payments never
+ * collide.</li>
+ * <li>The pathological "no description, no metadata" path no longer collapses
+ * to {@code "create-pi-0-..."} for every payment of the same amount.</li>
+ * </ol>
+ */
+class StripePaymentGatewayKeyTest {
+
+  private static final Method KEY = resolveMethod();
+
+  private static Method resolveMethod() {
+    try {
+      Method m = StripePaymentGateway.class.getDeclaredMethod(
+          "resolveIdempotencyKey", BigDecimal.class, String.class, String.class, Map.class);
+      m.setAccessible(true);
+      return m;
+    } catch (NoSuchMethodException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static String key(BigDecimal amount, String currency, String description, Map<String, String> meta)
+      throws Exception {
+    return (String) KEY.invoke(new StripePaymentGateway(), amount, currency, description, meta);
+  }
+
+  @Test
+  void callerSuppliedKeyWinsOutright() throws Exception {
+    Map<String, String> meta = new HashMap<>();
+    meta.put("idempotencyKey", "explicit-key-123");
+    meta.put("orderId", "ord-1");
+    String k = key(new BigDecimal("12.34"), "usd", "noise", meta);
+    assertEquals("explicit-key-123", k);
+  }
+
+  @Test
+  void identicalRequestsProduceIdenticalKey() throws Exception {
+    Map<String, String> meta = Map.of("orderId", "ord-42", "customerId", "cust-7");
+    String k1 = key(new BigDecimal("99.99"), "eur", "Order #42", meta);
+    String k2 = key(new BigDecimal("99.99"), "eur", "Order #42", new HashMap<>(meta));
+    assertEquals(k1, k2, "stable across retries of the same logical operation");
+    assertTrue(k1.startsWith("create-pi-"), "expected create-pi- prefix, got " + k1);
+  }
+
+  @Test
+  void differentOrderIdsProduceDifferentKeys() throws Exception {
+    String a = key(new BigDecimal("10.00"), "usd", "any", Map.of("orderId", "ord-1"));
+    String b = key(new BigDecimal("10.00"), "usd", "any", Map.of("orderId", "ord-2"));
+    assertNotEquals(a, b);
+  }
+
+  /**
+   * The original bug: with {@code description == null} and an empty metadata map,
+   * every payment of the same {@code amount + currency} collapsed onto the same
+   * key, causing Stripe to reject the second one.
+   */
+  @Test
+  void nullDescriptionWithoutMetadata_doesNotCollideAcrossPayments() throws Exception {
+    String a = key(new BigDecimal("25.00"), "usd", null, new HashMap<>());
+    String b = key(new BigDecimal("25.00"), "usd", null, new HashMap<>());
+    assertNotEquals(a, b, "no-context fallback must not collide across calls");
+    assertTrue(a.startsWith("create-pi-nocontext-"), "expected nocontext fallback, got " + a);
+  }
+
+  @Test
+  void differentAmountsProduceDifferentKeys() throws Exception {
+    String a = key(new BigDecimal("10.00"), "usd", "x", Map.of("orderId", "ord-1"));
+    String b = key(new BigDecimal("11.00"), "usd", "x", Map.of("orderId", "ord-1"));
+    assertNotEquals(a, b);
+  }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,6 +5,15 @@ stripe:
 spring:
   profiles:
     active: local
+  # Disable Hibernate Envers in tests: H2 (even in PostgreSQL mode) does not
+  # accept TINYINT, which Envers uses for the `revtype` column on every _AUD
+  # table. Production runs against Postgres where TINYINT is unnecessary.
+  jpa:
+    properties:
+      hibernate:
+        integration:
+          envers:
+            enabled: false
   mail:
     username: test-email-user
     password: test-email-password


### PR DESCRIPTION
## Summary

This PR closes every "known gap" listed at the bottom of the v1.0.0
`CHANGELOG.md` and ships v1.1.0. Schema changes are additive
(`V3__v1_1_release_features.sql`) so a rolling deploy is safe.

The branch is built from six logically-scoped commits — one per batch — to
keep review tractable despite the size:

1. `4a9f321` foundation: align cart schema with `carts`, publish `OrderPlaced`,
   fix `CartAbandoned` event payload.
2. `378a3d8` promotions + tax: full `Campaign.calculateDiscount` (BOGO,
   free-shipping, bundle), `TaxService` wired into `CheckoutService`, basic
   referral program.
3. `3baa92c` B2B + subscriptions: `CustomerGroup` / `PriceList` entities,
   `PriceListResolver` consulted by `CartService`, full subscription
   lifecycle (create / pause / resume / cancel / renew scheduler).
4. `acfc93e` multi-vendor checkout split + per-shop commission rate +
   `GET /customer-orders/{id}/children`.
5. `bf57d36` push tokens (FCM/APNs stub + opt-in plumbing), CMS blocks,
   product image variants (thumb/medium/large), soft-delete on
   `Product`/`Customer`/`Shop`, real co-purchase population on `OrderPlaced`.
6. `a1d4a5d` i18n product/category translations, Elasticsearch facets +
   bulk reindex, six new Thymeleaf email templates, Hibernate Envers
   auditing on `Customer`/`CustomerOrder`/`PaymentTransaction`/`Refund`,
   Resilience4j wrappers on Stripe/MinIO/Mail/ES, register the missing
   `priceLists`/`cms-blocks`/`tax` Caffeine caches.

See `CHANGELOG.md` for the per-area breakdown.

## New / changed endpoints

- `GET /api/v1/customer-orders/{orderId}/children` — list per-vendor child
  orders for a parent multi-vendor order.
- `GET /api/v1/cms/blocks/{code}` (public), `GET /api/v1/cms/blocks`,
  `POST /api/v1/cms/blocks` (admin), `DELETE /api/v1/cms/blocks/{id}`
  (admin) — storefront CMS blocks.
- `POST /api/v1/push-tokens/register`, `DELETE /api/v1/push-tokens`,
  `GET /api/v1/push-tokens` — customer-facing push token vault.
- `GET /api/v1/products?locale=…` and `GET /api/v1/products/{id}?locale=…`
  now apply translations from `product_translations` /
  `category_translations`.
- `GET /api/v1/search/faceted` — faceted product search (brand / category /
  price histogram aggregations) for storefront filter sidebars.
- `POST /api/v1/search/reindex` (admin-only) — bulk Elasticsearch reindex.

## Test plan

- [x] `./mvnw spotless:apply test` → `Tests run: 124, Failures: 0, Errors: 0`.
- [x] New `CmsAndCustomerOrderEndpointsTest` covers the CMS CRUD/read flow
      and the per-vendor child-orders endpoint via MockMvc.
- [x] Existing `CartIntegrationTest` and `OrderIntegrationTest` pass after
      the missing-cache fix in `CacheConfig`.
- [ ] Verify on a staging cluster that
      `V3__v1_1_release_features.sql` is idempotent on top of an existing
      V2 database (all `ADD COLUMN` / `CREATE TABLE` statements use
      `IF NOT EXISTS`).
- [ ] Smoke-test the new email templates against Mailhog locally.
- [ ] With `search.elasticsearch.enabled=true`, hit
      `POST /api/v1/search/reindex` and confirm hits show up under
      `/api/v1/search/faceted?q=…`.

## Risk & rollback

- Schema is additive only — rollback is a no-op (the new columns/tables
  remain unused).
- Hibernate Envers introduces `*_aud` tables for the four audited entities;
  these will start empty and grow with traffic. Disabling Envers is a
  one-line config (`spring.jpa.properties.hibernate.integration.envers.enabled=false`).
- Resilience4j circuit breakers default to permissive thresholds; they will
  log open/close transitions but should not produce user-visible errors.