### PR TITLE
chore(deps): patch 23 Dependabot advisories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.5</version>
 		<relativePath/>
 	</parent>
 
@@ -87,6 +87,24 @@
 		<commons-csv.version>1.14.1</commons-csv.version>
 		<logstash-logback.version>9.0</logstash-logback.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
+
+		<!-- ========= Security overrides on top of the Spring Boot BOM =========
+		     Each pin below is driven by an open Dependabot advisory. Keep them
+		     in lock-step with the BOM and remove once the parent catches up. -->
+		<!-- Spring Boot 4.0.5 still ships Tomcat 11.0.20; CVE-2026-34483,
+		     CVE-2026-34487 and CVE-2026-34500 require 11.0.21+. -->
+		<tomcat.version>11.0.21</tomcat.version>
+		<!-- Spring Boot 4.0.5 still ships Thymeleaf 3.1.3.RELEASE; CVE-2026-40477
+		     and CVE-2026-40478 (both critical) require 3.1.4.RELEASE+. -->
+		<thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
+		<!-- logstash-logback-encoder 9.0 transitively pulls Jackson 3.x, which
+		     the BOM pins at 3.1.0; advisories GHSA-72hv-8253-57qq,
+		     GHSA-2m67-wjpj-xhg9 and CVE-2026-29062 are fixed in 3.1.1+. -->
+		<jackson-bom.version>3.1.2</jackson-bom.version>
+		<!-- MinIO 9.0.0 transitively pulls Bouncy Castle 1.82; CVE-2026-0636
+		     (LDAP injection) requires 1.84+. The BOM does not manage it, so
+		     pin via dependencyManagement below. -->
+		<bouncycastle.version>1.84</bouncycastle.version>
 	</properties>
 
 	<dependencies>
@@ -366,12 +384,35 @@
 		</dependency>
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- Pin Bouncy Castle to a CVE-2026-0636 patched release. The MinIO
+			     SDK still depends on 1.82 transitively and the Spring Boot BOM
+			     does not manage these coordinates. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>4.0.1</version>
+				<version>4.0.5</version>
 				<configuration>
 					<excludes>
 						<exclude>


### PR DESCRIPTION
## Summary

Closes the open Dependabot backlog (6 critical / 8 high / 7 moderate / 2 low) that landed after the 4.x upgrade.

- Bump Spring Boot parent **4.0.1 → 4.0.5**, picking up Spring Framework 7.0.6, Spring Security 7.0.4, Jackson 2.21.2, Logback 1.5.32, AssertJ 3.27.7 and Spring Boot Actuator 4.0.5 (clears 8 advisories).
- Override `tomcat.version` → **11.0.21** (BOM still ships 11.0.20). Clears CVE-2026-25854, 29145, 32990, 24734, 34483, 34487, 34500.
- Override `thymeleaf.version` → **3.1.5.RELEASE** (BOM still ships 3.1.3). Clears the two critical Thymeleaf advisories CVE-2026-40477 / 40478.
- Override `jackson-bom.version` → **3.1.2** for the `tools.jackson` 3.x BOM that `logstash-logback-encoder` drags in (BOM pins 3.1.0). Clears CVE-2026-29062, GHSA-72hv-8253-57qq, GHSA-2m67-wjpj-xhg9.
- Pin **Bouncy Castle 1.84** in `<dependencyManagement>` because MinIO 9.0.0 still depends on 1.82 transitively and the BOM does not manage these coordinates. Clears CVE-2026-0636.
- Bump `spring-boot-maven-plugin` to 4.0.5 so the boot repackage goal stays aligned with the parent.

Each override has an inline comment naming the advisory(ies) so they're trivially removable once the parent BOM catches up.

## Test plan

- [x] `./mvnw clean compile` — green
- [x] `./mvnw test` — 148/148 tests passing, Spotless + Checkstyle clean
- [x] `./mvnw dependency:tree` — verified every advisory's `first_patched_version` is now on the classpath:
  - `bcprov-jdk18on:1.84`, `thymeleaf{,-spring6}:3.1.5.RELEASE`, `tomcat-embed-core:11.0.21`
  - `jackson-{core,databind}:2.21.2`, `tools.jackson.core:{core,databind}:3.1.2`
  - `spring-security-{web,core,config}:7.0.4`, `spring-webmvc:7.0.6`
  - `logback-{core,classic}:1.5.32`, `assertj-core:3.27.7`
- [ ] CI build & Dependabot rescan after merge to confirm all 23 alerts auto-close.