### PR TITLE
fix: post-merge cleanup for the narrative-comment strip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,27 +74,24 @@
 
 	<properties>
 		<java.version>25</java.version>
-		
+		<!-- Pinned: 2.4.x SpringBoot3Verifier rejects Spring Boot 4; track resilience4j#2267. -->
 		<resilience4j.version>2.3.0</resilience4j.version>
 		<bucket4j.version>8.10.1</bucket4j.version>
-		<!-- openpdf 3.x is a namespace rename (com.lowagie → org.openpdf) — hold
-		     at 2.x until we schedule the import migration. -->
+		<!-- openpdf 3.x is a namespace rename (com.lowagie → org.openpdf); hold at 2.x until import migration is scheduled. -->
 		<openpdf.version>2.0.3</openpdf.version>
 		<totp.version>1.7.1</totp.version>
 		<commons-csv.version>1.14.1</commons-csv.version>
 		<logstash-logback.version>9.0</logstash-logback.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 
-		
-		<!-- Spring Boot 4.0.5 still ships Tomcat 11.0.20; CVE-2026-34483,
-		     CVE-2026-34487 and CVE-2026-34500 require 11.0.21+. -->
+		<!-- Security overrides on top of the Spring Boot BOM (driven by open Dependabot advisories). -->
+		<!-- CVE-2026-34483 / CVE-2026-34487 / CVE-2026-34500 — require Tomcat 11.0.21+. -->
 		<tomcat.version>11.0.21</tomcat.version>
-		<!-- Spring Boot 4.0.5 still ships Thymeleaf 3.1.3.RELEASE; CVE-2026-40477
-		     and CVE-2026-40478 (both critical) require 3.1.4.RELEASE+. -->
+		<!-- CVE-2026-40477 / CVE-2026-40478 (critical) — require Thymeleaf 3.1.4.RELEASE+. -->
 		<thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
-		
+		<!-- GHSA-72hv-8253-57qq / GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 — require Jackson 3.1.1+. -->
 		<jackson-bom.version>3.1.2</jackson-bom.version>
-		
+		<!-- CVE-2026-0636 (Bouncy Castle LDAP injection) — require 1.84+; not managed by the BOM. -->
 		<bouncycastle.version>1.84</bouncycastle.version>
 	</properties>
 
@@ -163,7 +160,7 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		
+		<!-- Required: Spring Boot 4.x only activates FlywayAutoConfiguration via the starter, not plain flyway-core. -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-flyway</artifactId>
@@ -223,7 +220,7 @@
 			<artifactId>minio</artifactId>
 			<version>9.0.0</version>
 		</dependency>
-		
+		<!-- okhttp + kotlin-stdlib: transitive via MinIO; pinned only if a CVE forces an override (not currently). -->
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
@@ -367,7 +364,7 @@
 
 	<dependencyManagement>
 		<dependencies>
-			
+			<!-- Pin Bouncy Castle (CVE-2026-0636); MinIO still pulls 1.82 transitively and the BOM doesn't manage it. -->
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bcprov-jdk18on</artifactId>

--- a/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceListItem.java
+++ b/src/main/java/com/xplaza/backend/b2b/domain/entity/PriceListItem.java
@@ -11,6 +11,12 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * One row in a {@link PriceList}: the negotiated unit price for a product when
+ * bought in quantities ≥ {@code minQuantity}. Multiple rows for the same
+ * product implement quantity-break pricing — the resolver picks the highest
+ * {@code minQuantity} that the cart line still qualifies for.
+ */
 @Entity
 @Table(name = "price_list_items", uniqueConstraints = {
     @UniqueConstraint(columnNames = { "price_list_id", "product_id", "min_quantity" })

--- a/src/main/java/com/xplaza/backend/cart/domain/entity/Cart.java
+++ b/src/main/java/com/xplaza/backend/cart/domain/entity/Cart.java
@@ -17,6 +17,10 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Aggregate root representing a shopping cart. Supports both guest and
+ * authenticated customers.
+ */
 @Entity
 @Table(name = "carts", indexes = {
     @Index(name = "idx_cart_customer_id", columnList = "customer_id"),

--- a/src/main/java/com/xplaza/backend/cart/domain/entity/CartItem.java
+++ b/src/main/java/com/xplaza/backend/cart/domain/entity/CartItem.java
@@ -13,6 +13,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Entity representing an item in a shopping cart.
+ */
 @Entity
 @Table(name = "cart_items", indexes = {
     @Index(name = "idx_cart_item_cart_id", columnList = "cart_id"),

--- a/src/main/java/com/xplaza/backend/catalog/domain/entity/AttributeValue.java
+++ b/src/main/java/com/xplaza/backend/catalog/domain/entity/AttributeValue.java
@@ -11,6 +11,12 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Represents a possible value for an attribute.
+ * 
+ * Examples: - For "Color" attribute: Red, Blue, Green, Black, White - For
+ * "Size" attribute: XS, S, M, L, XL, XXL
+ */
 @Entity
 @Table(name = "attribute_values", uniqueConstraints = {
     @UniqueConstraint(columnNames = { "attribute_id", "code" })

--- a/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
+++ b/src/main/java/com/xplaza/backend/cms/domain/entity/CmsBlock.java
@@ -11,6 +11,12 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Storefront CMS block. Used for static content slots like the homepage hero
+ * banner, footer copy, return policy etc. Lookup is by the composite
+ * {@code (code, locale)} key so the same {@code code} can ship a localised
+ * variant per supported locale.
+ */
 @Entity
 @Table(name = "cms_blocks", uniqueConstraints = @UniqueConstraint(name = "uq_cms_blocks_code_locale", columnNames = {
     "code", "locale" }))

--- a/src/main/java/com/xplaza/backend/customer/domain/entity/WishlistItem.java
+++ b/src/main/java/com/xplaza/backend/customer/domain/entity/WishlistItem.java
@@ -13,6 +13,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * An item in a customer's wishlist.
+ */
 @Entity
 @Table(name = "wishlist_items", uniqueConstraints = {
     @UniqueConstraint(columnNames = { "wishlist_id", "product_id", "variant_id" })

--- a/src/main/java/com/xplaza/backend/fulfillment/domain/entity/Return.java
+++ b/src/main/java/com/xplaza/backend/fulfillment/domain/entity/Return.java
@@ -15,6 +15,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Return merchandise authorization (RMA).
+ */
 @Entity
 @Table(name = "returns", indexes = {
     @Index(name = "idx_returns_order", columnList = "order_id"),

--- a/src/main/java/com/xplaza/backend/fulfillment/domain/entity/Shipment.java
+++ b/src/main/java/com/xplaza/backend/fulfillment/domain/entity/Shipment.java
@@ -15,6 +15,11 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Represents a shipment for order fulfillment.
+ *
+ * A single order may have multiple shipments (split shipment).
+ */
 @Entity
 @Table(name = "shipments", indexes = {
     @Index(name = "idx_shipments_order", columnList = "order_id"),

--- a/src/main/java/com/xplaza/backend/fulfillment/domain/entity/ShipmentTrackingEvent.java
+++ b/src/main/java/com/xplaza/backend/fulfillment/domain/entity/ShipmentTrackingEvent.java
@@ -12,6 +12,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Tracking event for shipment.
+ */
 @Entity
 @Table(name = "shipment_tracking_events", indexes = {
     @Index(name = "idx_tracking_shipment", columnList = "shipment_id"),

--- a/src/main/java/com/xplaza/backend/inventory/domain/entity/InventoryItem.java
+++ b/src/main/java/com/xplaza/backend/inventory/domain/entity/InventoryItem.java
@@ -15,6 +15,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Inventory stock item per warehouse/variant combination.
+ */
 @Entity
 @Table(name = "inventory_items", indexes = {
     @Index(name = "idx_inventory_product", columnList = "product_id"),

--- a/src/main/java/com/xplaza/backend/inventory/domain/entity/InventoryMovement.java
+++ b/src/main/java/com/xplaza/backend/inventory/domain/entity/InventoryMovement.java
@@ -12,6 +12,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Inventory movement/transaction record.
+ */
 @Entity
 @Table(name = "inventory_movements", indexes = {
     @Index(name = "idx_movement_inventory", columnList = "inventory_id"),

--- a/src/main/java/com/xplaza/backend/inventory/domain/entity/StockReservation.java
+++ b/src/main/java/com/xplaza/backend/inventory/domain/entity/StockReservation.java
@@ -13,6 +13,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Stock reservation for orders.
+ */
 @Entity
 @Table(name = "stock_reservations", indexes = {
     @Index(name = "idx_reservation_inventory", columnList = "inventory_id"),

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/Campaign.java
@@ -14,6 +14,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Marketing campaign.
+ */
 @Entity
 @Table(name = "campaigns", indexes = {
     @Index(name = "idx_campaign_status", columnList = "status"),

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/CampaignProduct.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/CampaignProduct.java
@@ -12,6 +12,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Product included in a campaign with specific discount.
+ */
 @Entity
 @Table(name = "campaign_products", indexes = {
     @Index(name = "idx_campaign_product_campaign", columnList = "campaign_id"),

--- a/src/main/java/com/xplaza/backend/marketing/domain/entity/Referral.java
+++ b/src/main/java/com/xplaza/backend/marketing/domain/entity/Referral.java
@@ -12,6 +12,11 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Referral record. A customer (the {@code referrer}) sends an invitation to an
+ * email address; once that referee registers and places their first order the
+ * referral is marked {@code REWARDED} and the referrer is credited.
+ */
 @Entity
 @Table(name = "referrals", indexes = {
     @Index(name = "idx_referrals_referrer", columnList = "referrer_id"),

--- a/src/main/java/com/xplaza/backend/notification/domain/entity/Notification.java
+++ b/src/main/java/com/xplaza/backend/notification/domain/entity/Notification.java
@@ -12,6 +12,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Customer notification.
+ */
 @Entity
 @Table(name = "notifications", indexes = {
     @Index(name = "idx_notification_customer", columnList = "customer_id"),

--- a/src/main/java/com/xplaza/backend/order/domain/entity/CheckoutSession.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/CheckoutSession.java
@@ -15,6 +15,14 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Checkout session captures the checkout process before order confirmation.
+ *
+ * This allows customers to: - Review their cart - Select shipping address -
+ * Choose delivery slot - Select payment method - Apply coupons
+ *
+ * The checkout session expires after a certain time if not completed.
+ */
 @Entity
 @Table(name = "checkout_sessions", indexes = {
     @Index(name = "idx_checkout_cart", columnList = "cart_id"),

--- a/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrder.java
@@ -20,6 +20,13 @@ import lombok.*;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 
+/**
+ * CustomerOrder represents a confirmed purchase from a customer.
+ *
+ * An order is created when a customer completes checkout. It captures: - The
+ * items purchased (from cart) - Payment information - Shipping details -
+ * Pricing at time of purchase
+ */
 @Entity
 @Table(name = "customer_orders", indexes = {
     @Index(name = "idx_cust_orders_customer", columnList = "customer_id"),

--- a/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrderItem.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/CustomerOrderItem.java
@@ -13,6 +13,13 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * An item within a customer order.
+ *
+ * This is a snapshot of the product/variant at the time of purchase. All
+ * product details are copied so that the order remains accurate even if the
+ * product changes later.
+ */
 @Entity
 @Table(name = "customer_order_items", indexes = {
     @Index(name = "idx_cust_order_items_order", columnList = "order_id"),

--- a/src/main/java/com/xplaza/backend/order/domain/entity/OrderStatusHistory.java
+++ b/src/main/java/com/xplaza/backend/order/domain/entity/OrderStatusHistory.java
@@ -12,6 +12,9 @@ import jakarta.persistence.*;
 
 import lombok.*;
 
+/**
+ * Tracks the history of status changes for an order.
+ */
 @Entity
 @Table(name = "customer_order_status_history", indexes = {
     @Index(name = "idx_cust_order_status_history_order", columnList = "order_id")

--- a/src/main/resources/db/migration/V1__Initial_Schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_Schema.sql
@@ -1,7 +1,19 @@
+-- =====================================================
+-- X-Plaza Enterprise E-Commerce Schema
+-- Version: 1.0.0
+-- Date: 2025-12-06
+-- Description: Initial Schema
+-- =====================================================
 
+-- =====================================================
+-- SEQUENCES
+-- =====================================================
 
 CREATE SEQUENCE IF NOT EXISTS order_number_seq START WITH 1 INCREMENT BY 1;
 
+-- =====================================================
+-- CATALOG CONTEXT
+-- =====================================================
 
 -- Categories
 CREATE TABLE IF NOT EXISTS categories (
@@ -164,6 +176,9 @@ CREATE TABLE IF NOT EXISTS product_tags (
     PRIMARY KEY (product_id, tag)
 );
 
+-- =====================================================
+-- CUSTOMER CONTEXT
+-- =====================================================
 
 
 -- Admin Users
@@ -280,6 +295,9 @@ CREATE TABLE IF NOT EXISTS wishlist_items (
     UNIQUE(wishlist_id, product_id, variant_id)
 );
 
+-- =====================================================
+-- PROMOTION CONTEXT
+-- =====================================================
 
 -- Discount Types
 CREATE TABLE IF NOT EXISTS discount_types (
@@ -312,6 +330,9 @@ CREATE TABLE IF NOT EXISTS coupons (
     last_updated_at TIMESTAMP
 );
 
+-- =====================================================
+-- CART CONTEXT
+-- =====================================================
 
 -- Shopping Carts (proper implementation)
 CREATE TABLE IF NOT EXISTS carts (
@@ -361,6 +382,9 @@ CREATE TABLE IF NOT EXISTS cart_coupons (
 );
 
 
+-- =====================================================
+-- ORDER CONTEXT
+-- =====================================================
 
 -- Customer Orders
 CREATE TABLE IF NOT EXISTS customer_orders (
@@ -459,6 +483,9 @@ CREATE TABLE IF NOT EXISTS customer_order_items (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- REVIEW CONTEXT
+-- =====================================================
 
 -- Product Reviews
 CREATE TABLE IF NOT EXISTS reviews (
@@ -570,6 +597,9 @@ CREATE TABLE IF NOT EXISTS shop_ratings (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- PAYMENT CONTEXT
+-- =====================================================
 
 -- Payment Transactions
 CREATE TABLE IF NOT EXISTS payment_transactions (
@@ -673,6 +703,9 @@ CREATE TABLE IF NOT EXISTS refund_items (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- FULFILLMENT CONTEXT
+-- =====================================================
 
 -- Carriers
 CREATE TABLE IF NOT EXISTS carriers (
@@ -803,6 +836,9 @@ CREATE TABLE IF NOT EXISTS return_items (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- INVENTORY CONTEXT
+-- =====================================================
 
 -- Warehouses
 CREATE TABLE IF NOT EXISTS warehouses (
@@ -897,6 +933,9 @@ CREATE TABLE IF NOT EXISTS stock_reservations (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- VENDOR CONTEXT ENHANCEMENTS
+-- =====================================================
 
 -- Enhanced Shop columns
 ALTER TABLE shops ADD COLUMN IF NOT EXISTS slug VARCHAR(100);
@@ -987,6 +1026,9 @@ CREATE TABLE IF NOT EXISTS payout_items (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- PROMOTION CONTEXT ENHANCEMENTS
+-- =====================================================
 
 -- Campaigns (extends coupons)
 CREATE TABLE IF NOT EXISTS campaigns (
@@ -1045,6 +1087,9 @@ CREATE TABLE IF NOT EXISTS loyalty_transactions (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- NOTIFICATION CONTEXT
+-- =====================================================
 
 -- Notification Templates
 CREATE TABLE IF NOT EXISTS notification_templates (
@@ -1093,6 +1138,9 @@ CREATE TABLE IF NOT EXISTS notification_preferences (
     UNIQUE(user_id, user_type, channel, notification_type)
 );
 
+-- =====================================================
+-- ENHANCED ORDER COLUMNS
+-- =====================================================
 
 
 -- Order Items enhancements
@@ -1108,6 +1156,9 @@ CREATE TABLE IF NOT EXISTS order_history (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- =====================================================
+-- INDEXES FOR PERFORMANCE
+-- =====================================================
 
 -- Product Variants
 CREATE INDEX IF NOT EXISTS idx_variants_product ON product_variants(product_id);
@@ -1190,6 +1241,9 @@ CREATE INDEX IF NOT EXISTS idx_products_slug ON products(slug);
 CREATE INDEX IF NOT EXISTS idx_products_status ON products(status);
 CREATE INDEX IF NOT EXISTS idx_products_shop_category ON products(fk_shop_id, fk_category_id);
 
+-- =====================================================
+-- SEED DATA
+-- =====================================================
 
 -- Default Attributes
 INSERT INTO attributes (name, code, type, is_variant_attribute, is_filterable, is_searchable, position)

--- a/src/main/resources/db/migration/V2__v1_release_features.sql
+++ b/src/main/resources/db/migration/V2__v1_release_features.sql
@@ -1,3 +1,10 @@
+-- =====================================================
+-- X-Plaza v1.0.0 release features
+-- Adds: idempotency, transactional outbox, audit log,
+-- auth flows (verify/reset/MFA/OAuth), CMS, gift cards,
+-- subscriptions, B2B groups + price lists, tax engine,
+-- product translations, recommendations, full-text search.
+-- =====================================================
 
 -- ---------- Customers/Admins extras ----------
 ALTER TABLE customers ADD COLUMN IF NOT EXISTS oauth_provider VARCHAR(30);
@@ -240,6 +247,12 @@ CREATE TABLE IF NOT EXISTS price_list_items (
     UNIQUE(price_list_id, product_id, min_quantity)
 );
 
+-- ---------- Tax engine ----------
+-- Column names mirror the JPA entity exactly so that
+-- spring.jpa.hibernate.ddl-auto=validate (cloud profile) succeeds. The
+-- non-mapped `code` column is retained as a stable lookup key for the seed
+-- inserts below (Hibernate's `validate` only checks that mapped columns
+-- exist; extra columns are allowed).
 CREATE TABLE IF NOT EXISTS tax_zones (
     tax_zone_id          BIGSERIAL PRIMARY KEY,
     code                 VARCHAR(50) NOT NULL UNIQUE,

--- a/src/main/resources/db/migration/V3__v1_1_release_features.sql
+++ b/src/main/resources/db/migration/V3__v1_1_release_features.sql
@@ -1,4 +1,17 @@
+-- =====================================================
+-- X-Plaza v1.1.0 release features
+-- Adds: cart/JPA schema alignment, shop commission,
+-- B2B/subscriptions/translations Java entities, image
+-- variants, soft-delete metadata, referrals, parent/child
+-- order links, FCM push tokens.
+-- =====================================================
 
+-- ---------- Cart <-> JPA entity alignment ----------
+-- The Cart aggregate started life with a `shopping_carts` JPA mapping but the
+-- canonical Flyway schema created `carts`. v1.1.0 collapses this drift:
+-- the entity now points at `carts`. Add the columns the entity uses but the
+-- original `carts` DDL did not declare, and relax NOT NULL constraints on
+-- columns that JPA leaves to be re-derived in business methods.
 ALTER TABLE carts ADD COLUMN IF NOT EXISTS coupon_code VARCHAR(50);
 ALTER TABLE carts ADD COLUMN IF NOT EXISTS coupon_discount DECIMAL(10,2) DEFAULT 0;
 ALTER TABLE carts ADD COLUMN IF NOT EXISTS notes TEXT;
@@ -15,6 +28,11 @@ ALTER TABLE cart_items ADD COLUMN IF NOT EXISTS custom_attributes TEXT;
 ALTER TABLE cart_items ALTER COLUMN total_price DROP NOT NULL;
 ALTER TABLE cart_items ALTER COLUMN price_at_add DROP NOT NULL;
 
+-- ---------- Multi-vendor split orders ----------
+-- A checkout that spans products from N shops produces N child orders, each
+-- linked back to the umbrella order via `parent_order_id`. The parent order
+-- carries the customer-facing aggregates (grand total, payment); child
+-- orders own per-shop fulfilment (status history, payouts).
 ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS parent_order_id UUID;
 CREATE INDEX IF NOT EXISTS idx_orders_parent ON customer_orders(parent_order_id);
 
@@ -53,6 +71,10 @@ CREATE INDEX IF NOT EXISTS idx_referrals_email ON referrals(referee_email);
 -- Supports ReferralService.onOrderPlaced lookup by (referee_id, status).
 CREATE INDEX IF NOT EXISTS idx_referrals_referee_status ON referrals(referee_id, status);
 
+-- ---------- Product image variants ----------
+-- The ProductImage JPA entity expects a `product_images` table that the V1
+-- baseline never created (V1 only modelled per-variant `variant_images`).
+-- Create it here on the fly so the v1.1.0 image-pipeline columns can land.
 CREATE TABLE IF NOT EXISTS product_images (
     product_images_id   BIGSERIAL PRIMARY KEY,
     fk_product_id       BIGINT REFERENCES products(product_id) ON DELETE CASCADE,
@@ -77,16 +99,31 @@ ALTER TABLE customers ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
 CREATE INDEX IF NOT EXISTS idx_products_deleted_at  ON products(deleted_at);
 CREATE INDEX IF NOT EXISTS idx_customers_deleted_at ON customers(deleted_at);
 
+-- ---------- Subscription Java-entity tweaks ----------
+-- The base `subscriptions` table already exists from V2. The Java entity
+-- additionally tracks the active price-list snapshot, gateway customer id and
+-- the next attempt counter for retries.
 ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS gateway_customer_id VARCHAR(100);
 ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS retry_count         INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS last_error          VARCHAR(500);
 
+-- ---------- B2B price-list extras for the resolver ----------
+-- The resolver compares a candidate price list's currency to the cart's
+-- currency, so make currency NOT NULL to avoid surprises.
 ALTER TABLE price_list_items ADD COLUMN IF NOT EXISTS notes VARCHAR(500);
 
 -- ---------- Recommendation: align co-purchase table with JPA entity ----------
 ALTER TABLE product_co_purchases ADD COLUMN IF NOT EXISTS co_purchase_count BIGINT NOT NULL DEFAULT 0;
 CREATE INDEX IF NOT EXISTS idx_copurchases_count ON product_co_purchases(product_id, co_purchase_count DESC);
 
+-- ---------- CMS blocks: make (code, locale) the unique key ----------
+-- V2 created `cms_blocks` with UNIQUE(code), but the service/repository/cache
+-- look up by (code, locale) so the same `code` can ship a localised variant
+-- per supported locale (hero banner EN, FR, etc.). cms_blocks has not been
+-- populated in any deployment yet (v1.1.0 is where it is first user-visible),
+-- so a drop-and-recreate is safe and far more portable across H2/Postgres
+-- than a constraint-name-based ALTER (inline UNIQUE constraint names are not
+-- stable across dialects).
 DROP TABLE IF EXISTS cms_blocks;
 CREATE TABLE cms_blocks (
     id          BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Context

The narrative-strip sweep merged into `main` as part of #113 (squash merge at 15:33 UTC) before this follow-up landed. That merge carried three unintended regressions which this PR corrects:

## Summary

1. **Flyway safety — restore `V1` / `V2` / `V3` migrations to their pre-strip state.** Editing an already-applied `V*__` migration changes its checksum and breaks Flyway validation on every environment that already ran them. ⚠️ This is a production-blocking change — without this revert, the next deploy will fail on boot with a Flyway validation error. Any future narrative cleanup for migrations must go in a new `V_` file.

2. **`pom.xml` — restore security-override rationale.** Put back a one-line comment next to each CVE-driven version pin (`tomcat` / `thymeleaf` / `jackson` / `bouncycastle` / `resilience4j` / `openpdf` / `flyway-starter` / transitive `okhttp` / `dependencyManagement` BC) so the next maintainer can see *why* each pin exists and when to drop it.

3. **Class-level Javadoc — restore on 20 public entities.** The strip script had a bug: it did not skip continuation lines of multi-line annotations (e.g. `@Table(indexes = { ... })`), so it misclassified the preceding class-level `/** ... */` as non-class-level and dropped it. An auditor pass re-inserts those Javadocs verbatim from `main@pre-strip`. Copilot flagged 3 of these (`CustomerOrder`, `CheckoutSession`, `Notification`); this restores all 20.

## Test plan

- [x] `./mvnw -B spotless:apply test` — **148 / 148 green**, Spotless clean
- [ ] Verify on a deployment environment that Flyway validation passes on boot (pre-existing applied `V1`/`V2`/`V3` checksums match)