### PR TITLE
chore(logging): reduce boot noise to a minimum

### DIFF
--- a/src/main/resources/application-cloud.yaml
+++ b/src/main/resources/application-cloud.yaml
@@ -87,4 +87,7 @@ xplaza:
 
 logging:
   level:
+    root: ${ROOT_LOG_LEVEL:WARN}
     com.xplaza.backend: ${LOG_LEVEL:INFO}
+    org.springframework.data.repository.config: ERROR
+    org.hibernate.SQL: WARN

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,10 @@ spring:
   application:
     name: Xplaza-Backend
 
+  main:
+    banner-mode: off
+    log-startup-info: false
+
   profiles:
     active: local
 
@@ -171,9 +175,25 @@ push:
 
 logging:
   level:
-    org.springframework.security: INFO
-    org.springframework.web: INFO
+    root: WARN
     com.xplaza.backend: INFO
+    org.springframework: WARN
+    org.springframework.boot.autoconfigure: WARN
+    org.springframework.data: WARN
+    org.springframework.data.repository.config: ERROR
+    org.springframework.web: WARN
+    org.springframework.security: WARN
+    org.hibernate: WARN
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.deprecation: ERROR
+    org.apache.catalina: WARN
+    org.apache.coyote: WARN
+    com.zaxxer.hikari: WARN
+    io.lettuce.core: WARN
+    io.netty: WARN
+    org.flywaydb: INFO
+    org.elasticsearch: WARN
+    co.elastic.clients: WARN
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [traceId=%X{traceId:-},spanId=%X{spanId:-}] %-5level %logger{36} - %msg%n"
 


### PR DESCRIPTION
## Problem

Production boot output is dominated by Spring Data
\"Could not safely identify store assignment for repository candidate\"
INFO lines — one per \`@Repository\` per store module (JPA +
Elasticsearch + Reactive Elasticsearch ≈ 100+ lines on every boot).
They make real errors hard to spot and they blow up log bills.

## Fix

Tighten default log levels in \`application.yaml\` and \`application-cloud.yaml\`:

| Logger | Level |
|---|---|
| root | WARN |
| \`com.xplaza.backend\` | INFO |
| \`org.springframework.data.repository.config\` | **ERROR** (kills the store-identification noise) |
| \`org.hibernate.SQL\` | WARN |
| \`org.springframework\` / \`.web\` / \`.security\` / \`.boot.autoconfigure\` | WARN |
| \`org.hibernate\` / \`.orm.deprecation\` | WARN / ERROR |
| \`org.apache.catalina\` / \`.coyote\` | WARN |
| \`com.zaxxer.hikari\` / \`io.lettuce.core\` / \`io.netty\` | WARN |
| \`org.elasticsearch\` / \`co.elastic.clients\` | WARN |
| \`org.flywaydb\` | INFO (we still want migration lines) |

Also:

- \`spring.main.banner-mode: off\`
- \`spring.main.log-startup-info: false\` — skip the \"Starting Xplaza-Backend using Java 25\" / system-properties dump
- Cloud profile exposes \`ROOT_LOG_LEVEL\` / \`LOG_LEVEL\` env vars so operators can raise verbosity on demand without a redeploy.

## Test plan

- [x] \`./mvnw -B test\` — **154 / 154** green
- [x] Spotless clean