### PR TITLE
fix(flyway): heal shopping_carts->carts drift before V2 indexes

### DIFF
--- a/src/main/resources/db/migration/V2__v1_release_features.sql
+++ b/src/main/resources/db/migration/V2__v1_release_features.sql
@@ -6,6 +6,53 @@
 -- product translations, recommendations, full-text search.
 -- =====================================================
 
+-- ---------- Compatibility preamble (cart table rename) ----------
+-- Early production environments ran with `spring.flyway.baseline-on-migrate=true`
+-- against a schema that Hibernate `ddl-auto=update` had already built. In that
+-- era the Cart aggregate mapped to `shopping_carts` (see commit 4a9f321 — the
+-- rename to `carts`). Because baseline-on-migrate back-stamped V1 as "applied"
+-- without executing its body, the canonical `carts` table from V1 never got
+-- created on those environments. V2 (below) indexes `carts(...)` and therefore
+-- fails with `relation "carts" does not exist`.
+--
+-- This block heals that drift idempotently:
+--   1. If `carts` is missing but `shopping_carts` exists -> rename it.
+--   2. If neither exists (clean DB that baselined on an even older schema) ->
+--      fall through to the CREATE TABLE IF NOT EXISTS below.
+-- Column-level drift (e.g. `id` vs `cart_id`, `currency_code` vs `currency`)
+-- is still covered by Hibernate `ddl-auto=update` until V4 reconciliation.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = current_schema() AND table_name = 'carts'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = current_schema() AND table_name = 'shopping_carts'
+  ) THEN
+    EXECUTE 'ALTER TABLE shopping_carts RENAME TO carts';
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS carts (
+    cart_id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    customer_id BIGINT REFERENCES customers(customer_id) ON DELETE SET NULL,
+    session_id VARCHAR(100),
+    status VARCHAR(20) DEFAULT 'ACTIVE',
+    currency VARCHAR(3) DEFAULT 'USD',
+    subtotal DECIMAL(15, 2) DEFAULT 0,
+    discount_total DECIMAL(15, 2) DEFAULT 0,
+    shipping_estimate DECIMAL(15, 2) DEFAULT 0,
+    tax_estimate DECIMAL(15, 2) DEFAULT 0,
+    total_estimate DECIMAL(15, 2) DEFAULT 0,
+    item_count INTEGER DEFAULT 0,
+    converted_order_id UUID,
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 -- ---------- Customers/Admins extras ----------
 ALTER TABLE customers ADD COLUMN IF NOT EXISTS oauth_provider VARCHAR(30);
 ALTER TABLE customers ADD COLUMN IF NOT EXISTS oauth_subject VARCHAR(200);


### PR DESCRIPTION
## Why production is looping

Latest deploy logs show:

```
Migrating schema "public" to version "2 - v1 release features"
ERROR: relation "carts" does not exist
Location : db/migration/V2__v1_release_features.sql  (Line 366)
```

Flyway then rolls V2 back, `flywayInitializer` fails, and the whole bean graph (`entityManagerFactory` -> JPA repos -> `jwtRequestFilter` -> Tomcat) unwinds. Restart loop.

## Root cause

1. Prod was long-lived with `spring.jpa.hibernate.ddl-auto=update` before Flyway was introduced.
2. Back then the Cart aggregate mapped to **`shopping_carts`** — see commit `4a9f321` (*"align cart schema with carts table, publish OrderPlaced..."*) which renamed the `@Table` to `carts`.
3. When Flyway was turned on, `spring.flyway.baseline-on-migrate=true` back-stamped V1 as applied **without executing its body**, so V1's `CREATE TABLE carts (...)` never ran in prod.
4. V2 (introduced later) blindly runs `CREATE INDEX ... ON carts(...)` at line 366 -> 💥 because prod only has the legacy `shopping_carts` table.

This only affects environments that baselined during the Hibernate-owned era; clean envs (where V1 actually executed) are unaffected because `carts` already exists there.

## Fix

Prepend V2 with an idempotent compatibility block:

1. If `carts` is missing but `shopping_carts` exists -> `ALTER TABLE shopping_carts RENAME TO carts;` (production path — preserves data, FKs, customer_id/session_id/status/updated_at columns that the subsequent indexes need).
2. Fall-through `CREATE TABLE IF NOT EXISTS carts (...)` mirroring V1's canonical DDL, so environments baselined on an even older schema still get a valid target for V2's indexes.

Column-level drift (`id`/`cart_id`, `currency_code`/`currency`, etc.) stays owned by Hibernate `ddl-auto=update` until the planned V4 reconciliation migration — already tracked as a TODO in `application-cloud.yaml`.

### Checksum safety

The current prod `flyway_schema_history` row for V2 is `success=false` (rolled-back). Flyway does **not** checksum-lock failed rows, so the next boot picks up the new V2 content and retries it end-to-end. No manual `flyway repair` is required.

## Local validation (Postgres 17)

**Rename path** (simulates prod):

```
pre:  customers, shopping_carts (id UUID, customer_id, session_id, status, currency_code, ...)
post: customers, carts (id UUID ...), indexes idx_carts_customer / idx_carts_session / idx_carts_status_updated ✓
      shopping_carts_leftover = 0
```

**Fresh path** (clean DB):

```
pre:  customers
post: customers, carts (cart_id UUID PK, FK -> customers, ...), V2 indexes succeed ✓
```

Both paths let V2 proceed past line 366.

## Test plan

- [x] `ALTER TABLE shopping_carts RENAME TO carts` executes and the three V2 indexes succeed on a simulated prod snapshot.
- [x] Fresh DB: V2 creates `carts` from V1's canonical DDL and indexes succeed.
- [x] `./mvnw spotless:check` passes.
- [ ] Merge and redeploy; expect Flyway to go `1 -> 2 -> 3` and the context to come up cleanly.